### PR TITLE
🪲 [Fix]: Enforce `Run_PassThru` to be `$true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ jobs:
 
 ### Inputs
 
-All are **optional** unless otherwise noted. For more info on the configuration options, see the [Pester documentation](https://pester.dev/docs/usage/configuration).
+All are **optional** unless otherwise noted. For more info on the configuration options, see the
+[Pester Configuration documentation](https://pester.dev/docs/usage/configuration).
+`Run.PassThru` is forced to `$true` to ensure the action can capture test results.
 
 | **Input**                            | **Description**                                                                                        | **Default**                     |
 |--------------------------------------|--------------------------------------------------------------------------------------------------------|---------------------------------|
@@ -164,7 +166,6 @@ All are **optional** unless otherwise noted. For more info on the configuration 
 | `Run_TestExtension`                  | Filter used to identify test files (e.g. `.Tests.ps1`).                                                | *(none)*                        |
 | `Run_Exit`                           | Whether to exit with a non-zero exit code on failure.                                                  | *(none)*                        |
 | `Run_Throw`                          | Whether to throw an exception on test failure.                                                         | *(none)*                        |
-| `Run_PassThru`                       | Return result object to pipeline after finishing the test run.                                         | *(none)*                        |
 | `Run_SkipRun`                        | Discovery only, skip actual test run.                                                                  | *(none)*                        |
 | `Run_SkipRemainingOnFailure`         | Skips remaining tests after the first failure. Options: `None`, `Run`, `Container`, `Block`.           | *(none)*                        |
 | `Filter_Tag`                         | Tags of Describe/Context/It blocks to run.                                                             | *(none)*                        |

--- a/action.yml
+++ b/action.yml
@@ -40,10 +40,6 @@ inputs:
     description: |
       Throw an exception when test run fails. When used together with Exit, throwing an exception is preferred.
     required: false
-  Run_PassThru:
-    description: |
-      Return result object to the pipeline after finishing the test run.
-    required: false
   Run_SkipRun:
     description: |
       Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests.
@@ -309,7 +305,6 @@ runs:
         GITHUB_ACTION_INPUT_Run_TestExtension: ${{ inputs.Run_TestExtension }}
         GITHUB_ACTION_INPUT_Run_Exit: ${{ inputs.Run_Exit }}
         GITHUB_ACTION_INPUT_Run_Throw: ${{ inputs.Run_Throw }}
-        GITHUB_ACTION_INPUT_Run_PassThru: ${{ inputs.Run_PassThru }}
         GITHUB_ACTION_INPUT_Run_SkipRun: ${{ inputs.Run_SkipRun }}
         GITHUB_ACTION_INPUT_Run_SkipRemainingOnFailure: ${{ inputs.Run_SkipRemainingOnFailure }}
         GITHUB_ACTION_INPUT_Filter_Tag: ${{ inputs.Filter_Tag }}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -32,7 +32,6 @@ LogGroup 'Load inputs' {
         Run_TestExtension                  = $env:GITHUB_ACTION_INPUT_Run_TestExtension
         Run_Exit                           = $env:GITHUB_ACTION_INPUT_Run_Exit
         Run_Throw                          = $env:GITHUB_ACTION_INPUT_Run_Throw
-        Run_PassThru                       = $env:GITHUB_ACTION_INPUT_Run_PassThru
         Run_SkipRun                        = $env:GITHUB_ACTION_INPUT_Run_SkipRun
         Run_SkipRemainingOnFailure         = $env:GITHUB_ACTION_INPUT_Run_SkipRemainingOnFailure
 
@@ -130,7 +129,6 @@ LogGroup 'Load configuration - Action overrides' {
             TestExtension          = $inputs.Run_TestExtension
             Exit                   = $inputs.Run_Exit
             Throw                  = $inputs.Run_Throw
-            PassThru               = $inputs.Run_PassThru
             SkipRun                = $inputs.Run_SkipRun
             SkipRemainingOnFailure = $inputs.Run_SkipRemainingOnFailure
         }
@@ -247,6 +245,9 @@ LogGroup 'Load configuration - Result' {
     $artifactName = $configuration.TestResult.TestSuiteName
     $configuration.TestResult.OutputPath = "test_reports/$artifactName-TestResult-Report.xml"
     $configuration.CodeCoverage.OutputPath = "test_reports/$artifactName-CodeCoverage-Report.xml"
+    $configuration.Run.PassThru = $true
+
+    $configuration = New-PesterConfiguration -Hashtable $configuration
 
     Write-Output ($configuration | ConvertTo-Json -Depth 5 -WarningAction SilentlyContinue)
 }


### PR DESCRIPTION
## Description

This pull requests main focus is on ensuring that the `Run.PassThru` option is always set to `$true` to capture test results, and removing redundant configurations related to `Run.PassThru`.

### Documentation Updates

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R157): Updated the documentation to clarify that `Run.PassThru` is forced to `$true` and removed the redundant `Run_PassThru` input description. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R157) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L167)

### Configuration File Updates

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L43-L46): Removed the `Run_PassThru` input configuration as it is now always set to `$true` within the script. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L43-L46) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L312)

### Script Updates

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L35): Removed references to `Run_PassThru` from the script and added a line to set `Run.PassThru` to `$true` in the configuration. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L35) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L133) [[3]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011R248-R250)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
