### PR TITLE
🩹 [Patch]: Remove dependency on `PSScriptAnalyzer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This GitHub Action runs [Pester](https://pester.dev) tests in PowerShell, producing code coverage and test result artifacts. It automates many tasks
 to streamline continuous integration for PowerShell projects:
 
-- Installation and import of required modules (Pester, PSScriptAnalyzer).
+- Installation and import of required modules.
 - Automatic merging of default configuration, test suite configuration, and direct inputs into a final Pester configuration.
 - Optional uploading of test results and coverage reports.
 - Clear step summary in GitHub's job logs.
@@ -41,7 +41,7 @@ This **“last-write-wins”** strategy means you can set global defaults while 
 ## How This Action Processes Your Tests
 
 1. **Prerequisite Setup**
-   - Installs required PowerShell modules (Pester, PSScriptAnalyzer) if they're not present.
+   - Installs required PowerShell modules if they're not present.
    - Imports the modules so the testing framework is ready to use.
 
 2. **Loading Inputs and Configuration**

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -3,7 +3,7 @@
 param()
 
 LogGroup 'Setup prerequisites' {
-    'Pester', 'PSScriptAnalyzer', 'Hashtable', 'TimeSpan' | ForEach-Object {
+    'Pester', 'Hashtable', 'TimeSpan' | ForEach-Object {
         Install-PSResource -Name $_ -Verbose:$false -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery
         Import-Module -Name $_ -Verbose:$false
     }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -11,13 +11,11 @@ LogGroup 'Setup prerequisites' {
 }
 
 LogGroup 'Get test kit versions' {
-    $PSSAModule = Get-PSResource -Name PSScriptAnalyzer -Verbose:$false | Sort-Object Version -Descending | Select-Object -First 1
     $pesterModule = Get-PSResource -Name Pester -Verbose:$false | Sort-Object Version -Descending | Select-Object -First 1
 
     [PSCustomObject]@{
-        PowerShell       = $PSVersionTable.PSVersion.ToString()
-        Pester           = $pesterModule.Version
-        PSScriptAnalyzer = $PSSAModule.Version
+        PowerShell = $PSVersionTable.PSVersion.ToString()
+        Pester     = $pesterModule.Version
     } | Format-List
 }
 


### PR DESCRIPTION
## Description

This pull request focuses on removing the dependency on the `PSScriptAnalyzer` module from the project. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6): Removed references to `PSScriptAnalyzer` in the installation and import instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44)

Script updates:

* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L6-L20): Removed `PSScriptAnalyzer` from the list of modules to install and import, and from the test kit version retrieval logic.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
