### PR TITLE
🩹 [Patch]: Allow external continue-on-error, and add status in action

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -97,7 +97,7 @@ jobs:
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
           # Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
-  ActionTestAdvanced:
+  ActionTest3Advanced:
     name: Action-Test - [3-Advanced]
     runs-on: ubuntu-latest
     outputs:
@@ -129,7 +129,7 @@ jobs:
       - ActionTest1Simple
       - ActionTest1SimpleFailure
       - ActionTest2Standard
-      - ActionTestAdvanced
+      - ActionTest3Advanced
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -137,28 +137,88 @@ jobs:
         shell: pwsh
         run: |
           # Build an array of objects for each job
+          $ActionTest1SimpleOutcome = "${{ needs.ActionTest1Simple.outputs.outcome }}"
+          $ActionTest1SimpleExpectedOutcome = "success"
+          $ActionTest1SimpleOutcomeResult = $ActionTest1SimpleOutcome -eq $ActionTest1SimpleExpectedOutcome
+          $ActionTest1SimpleConclusion = "${{ needs.ActionTest1Simple.outputs.conclusion }}"
+          $ActionTest1SimpleExpectedConclusion = "success"
+          $ActionTest1SimpleConclusionResult = $ActionTest1SimpleConclusion -eq $ActionTest1SimpleExpectedConclusion
+          $ActionTest1SimpleFailureOutcome = "${{ needs.ActionTest1SimpleFailure.outputs.outcome }}"
+          $ActionTest1SimpleFailureExpectedOutcome = "failure"
+          $ActionTest1SimpleFailureOutcomeResult = $ActionTest1SimpleFailureOutcome -eq $ActionTest1SimpleFailureExpectedOutcome
+          $ActionTest1SimpleFailureConclusion = "${{ needs.ActionTest1SimpleFailure.outputs.conclusion }}"
+          $ActionTest1SimpleFailureExpectedConclusion = "success"
+          $ActionTest1SimpleFailureConclusionResult = $ActionTest1SimpleFailureConclusion -eq $ActionTest1SimpleFailureExpectedConclusion
+          $ActionTest2StandardOutcome = "${{ needs.ActionTest2Standard.outputs.outcome }}"
+          $ActionTest2StandardExpectedOutcome = "success"
+          $ActionTest2StandardOutcomeResult = $ActionTest2StandardOutcome -eq $ActionTest2StandardExpectedOutcome
+          $ActionTest2StandardConclusion = "${{ needs.ActionTest2Standard.outputs.conclusion }}"
+          $ActionTest2StandardExpectedConclusion = "success"
+          $ActionTest2StandardConclusionResult = $ActionTest2StandardConclusion -eq $ActionTest2StandardExpectedConclusion
+          $ActionTest3AdvancedOutcome = "${{ needs.ActionTest3Advanced.outputs.outcome }}"
+          $ActionTest3AdvancedExpectedOutcome = "success"
+          $ActionTest3AdvancedOutcomeResult = $ActionTest3AdvancedOutcome -eq $ActionTest3AdvancedExpectedOutcome
+          $ActionTest3AdvancedConclusion = "${{ needs.ActionTest3Advanced.outputs.conclusion }}"
+          $ActionTest3AdvancedExpectedConclusion = "success"
+          $ActionTest3AdvancedConclusionResult = $ActionTest3AdvancedConclusion -eq $ActionTest3AdvancedExpectedConclusion
+
+
           $jobs = @(
             [PSCustomObject]@{
-              Name       = "ActionTest1Simple"
-              Outcome    = "${{ needs.ActionTest1Simple.outputs.outcome }}"
-              Conclusion = "${{ needs.ActionTest1Simple.outputs.conclusion }}"
+              Name               = "ActionTest1Simple"
+              Outcome            = $ActionTest1SimpleOutcome
+              ExpectedOutcome    = $ActionTest1SimpleExpectedOutcome
+              PassedOutcome      = $ActionTest1SimpleOutcomeResult
+              Conclusion         = $ActionTest1SimpleConclusion
+              ExpectedConclusion = $ActionTest1SimpleExpectedConclusion
+              PassedConclusion   = $ActionTest1SimpleConclusionResult
             },
             [PSCustomObject]@{
-              Name       = "ActionTest1SimpleFailure"
-              Outcome    = "${{ needs.ActionTest1SimpleFailure.outputs.outcome }}"
-              Conclusion = "${{ needs.ActionTest1SimpleFailure.outputs.conclusion }}"
+              Name               = "ActionTest1SimpleFailure"
+              Outcome            = $ActionTest1SimpleFailureOutcome
+              ExpectedOutcome    = $ActionTest1SimpleFailureExpectedOutcome
+              PassedOutcome      = $ActionTest1SimpleFailureOutcomeResult
+              Conclusion         = $ActionTest1SimpleFailureConclusion
+              ExpectedConclusion = $ActionTest1SimpleFailureExpectedConclusion
+              PassedConclusion   = $ActionTest1SimpleFailureConclusionResult
             },
             [PSCustomObject]@{
-              Name       = "ActionTest2Standard"
-              Outcome    = "${{ needs.ActionTest2Standard.outputs.outcome }}"
-              Conclusion = "${{ needs.ActionTest2Standard.outputs.conclusion }}"
+              Name               = "ActionTest2Standard"
+              Outcome            = $ActionTest2StandardOutcome
+              ExpectedOutcome    = $ActionTest2StandardExpectedOutcome
+              PassedOutcome      = $ActionTest2StandardOutcomeResult
+              Conclusion         = $ActionTest2StandardConclusion
+              ExpectedConclusion = $ActionTest2StandardExpectedConclusion
+              PassedConclusion   = $ActionTest2StandardConclusionResult
             },
             [PSCustomObject]@{
-              Name       = "ActionTestAdvanced"
-              Outcome    = "${{ needs.ActionTestAdvanced.outputs.outcome }}"
-              Conclusion = "${{ needs.ActionTestAdvanced.outputs.conclusion }}"
+              Name               = "ActionTest3Advanced"
+              Outcome            = $ActionTest3AdvancedOutcome
+              ExpectedOutcome    = $ActionTest3AdvancedExpectedOutcome
+              PassedOutcome      = $ActionTest3AdvancedOutcomeResult
+              Conclusion         = $ActionTest3AdvancedConclusion
+              ExpectedConclusion = $ActionTest3AdvancedExpectedConclusion
+              PassedConclusion   = $ActionTest3AdvancedConclusionResult
             }
           )
 
           # Display the table in the workflow logs
           $jobs | Format-Table -AutoSize
+
+          $passed = $true
+          $jobs | ForEach-Object {
+            if (-not $_.PassedOutcome) {
+              Write-Error "Job $($_.Name) failed with Outcome $($_.Outcome) and Expected Outcome $($_.ExpectedOutcome)"
+              $passed = $false
+            }
+
+            if (-not $_.PassedConclusion) {
+              Write-Error "Job $($_.Name) failed with Conclusion $($_.Conclusion) and Expected Conclusion $($_.ExpectedConclusion)"
+              $passed = $false
+            }
+          }
+
+          if (-not $passed) {
+            Write-GithubError "One or more jobs failed"
+            exit 1
+          }

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -203,7 +203,7 @@ jobs:
           )
 
           # Display the table in the workflow logs
-          $jobs | Format-Table -AutoSize
+          $jobs | Format-List
 
           $passed = $true
           $jobs | ForEach-Object {

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -20,6 +20,9 @@ jobs:
   ActionTest1Simple:
     name: Action-Test - [1-Simple]
     runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.action-test.outputs.outcome }}
+      conclusion: ${{ steps.action-test.outputs.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -43,6 +46,9 @@ jobs:
   ActionTest1SimpleFailure:
     name: Action-Test - [1-Simple-Failure]
     runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.action-test.outputs.outcome }}
+      conclusion: ${{ steps.action-test.outputs.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -67,6 +73,9 @@ jobs:
   ActionTest2Standard:
     name: Action-Test - [2-Standard]
     runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.action-test.outputs.outcome }}
+      conclusion: ${{ steps.action-test.outputs.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -81,16 +90,6 @@ jobs:
 
       - name: Status
         shell: pwsh
-        env:
-          PASSED: ${{ steps.action-test.outputs.passed }}
-        run: |
-          Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -ne 'true') {
-            exit 1
-          }
-
-      - name: Status
-        shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
           Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
@@ -101,6 +100,9 @@ jobs:
   ActionTestAdvanced:
     name: Action-Test - [3-Advanced]
     runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.action-test.outputs.outcome }}
+      conclusion: ${{ steps.action-test.outputs.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Status
         shell: pwsh
         run: |
-          '${{ fromJson(steps) }}' | ConvertFrom-Json
+          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
 
   ActionTest2Standard:
     name: Action-Test - [2-Standard]

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -41,6 +41,21 @@ jobs:
             exit 1
           }
 
+  ActionTest1SimpleFailure:
+    name: Action-Test - [1-Simple-Failure]
+    runs-on: ubuntu-latest
+    steps:
+      # Need to check out as part of the test, as its a local action
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Action-Test [1-Simple-Failure]
+        uses: ./
+        id: action-test
+        with:
+          continue-on-error: true
+          Path: tests/1-Simple-Failure
+
   ActionTest2Standard:
     name: Action-Test - [2-Standard]
     runs-on: ubuntu-latest

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -59,10 +59,7 @@ jobs:
       - name: Status
         shell: pwsh
         run: |
-          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
-          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
-
-          Write-Host ('${{ fromJson(steps.action-test) }}' | ConvertFrom-Json)
+          '${{ fromJson(steps) }}' | ConvertFrom-Json
 
   ActionTest2Standard:
     name: Action-Test - [2-Standard]

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -52,9 +52,17 @@ jobs:
       - name: Action-Test [1-Simple-Failure]
         uses: ./
         id: action-test
+        continue-on-error: true
         with:
-          continue-on-error: true
           Path: tests/1-Simple-Failure
+
+      - name: Status
+        shell: pwsh
+        run: |
+          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+
+          Write-Host ('${{ fromJson(steps.action-test) }}' | ConvertFrom-Json)
 
   ActionTest2Standard:
     name: Action-Test - [2-Standard]

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -33,13 +33,9 @@ jobs:
 
       - name: Status
         shell: pwsh
-        env:
-          PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
-          Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -ne 'true') {
-            exit 1
-          }
+          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
 
   ActionTest1SimpleFailure:
     name: Action-Test - [1-Simple-Failure]
@@ -87,6 +83,12 @@ jobs:
             exit 1
           }
 
+      - name: Status
+        shell: pwsh
+        run: |
+          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+
   ActionTestAdvanced:
     name: Action-Test - [3-Advanced]
     runs-on: ubuntu-latest
@@ -103,10 +105,46 @@ jobs:
 
       - name: Status
         shell: pwsh
-        env:
-          PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
-          Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -ne 'true') {
-            exit 1
-          }
+          Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+
+  CatchJob:
+    name: "Catch Job - Aggregate Status"
+    needs:
+      - ActionTest1Simple
+      - ActionTest1SimpleFailure
+      - ActionTest2Standard
+      - ActionTestAdvanced
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Display Aggregated Results as a Table"
+        shell: pwsh
+        run: |
+          # Build an array of objects for each job
+          $jobs = @(
+            [PSCustomObject]@{
+              Name       = "ActionTest1Simple"
+              Outcome    = "${{ needs.ActionTest1Simple.outputs.outcome }}"
+              Conclusion = "${{ needs.ActionTest1Simple.outputs.conclusion }}"
+            },
+            [PSCustomObject]@{
+              Name       = "ActionTest1SimpleFailure"
+              Outcome    = "${{ needs.ActionTest1SimpleFailure.outputs.outcome }}"
+              Conclusion = "${{ needs.ActionTest1SimpleFailure.outputs.conclusion }}"
+            },
+            [PSCustomObject]@{
+              Name       = "ActionTest2Standard"
+              Outcome    = "${{ needs.ActionTest2Standard.outputs.outcome }}"
+              Conclusion = "${{ needs.ActionTest2Standard.outputs.conclusion }}"
+            },
+            [PSCustomObject]@{
+              Name       = "ActionTestAdvanced"
+              Outcome    = "${{ needs.ActionTestAdvanced.outputs.outcome }}"
+              Conclusion = "${{ needs.ActionTestAdvanced.outputs.conclusion }}"
+            }
+          )
+
+          # Display the table in the workflow logs
+          $jobs | Format-Table -AutoSize

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Action-Test [1-Simple-Failure]
         uses: ./
         id: action-test
-        continue-on-error: true
+        # continue-on-error: true
         with:
           Path: tests/1-Simple-Failure
 

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Action-Test [1-Simple-Failure]
         uses: ./
         id: action-test
-        # continue-on-error: true
+        continue-on-error: true
         with:
           Path: tests/1-Simple-Failure
 

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -35,7 +35,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTest1SimpleFailure:
     name: Action-Test - [1-Simple-Failure]
@@ -56,7 +59,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTest2Standard:
     name: Action-Test - [2-Standard]
@@ -87,7 +93,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTestAdvanced:
     name: Action-Test - [3-Advanced]
@@ -107,7 +116,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
+          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
+          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   CatchJob:
     name: "Catch Job - Aggregate Status"

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -21,8 +21,8 @@ jobs:
     name: Action-Test - [1-Simple]
     runs-on: ubuntu-latest
     outputs:
-      outcome: ${{ steps.action-test.outputs.outcome }}
-      conclusion: ${{ steps.action-test.outputs.conclusion }}
+      outcome: ${{ steps.action-test.outcome }}
+      conclusion: ${{ steps.action-test.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -38,17 +38,17 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
-          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+          # Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
 
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
-          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
+          # Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTest1SimpleFailure:
     name: Action-Test - [1-Simple-Failure]
     runs-on: ubuntu-latest
     outputs:
-      outcome: ${{ steps.action-test.outputs.outcome }}
-      conclusion: ${{ steps.action-test.outputs.conclusion }}
+      outcome: ${{ steps.action-test.outcome }}
+      conclusion: ${{ steps.action-test.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -65,17 +65,17 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
-          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+          # Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
 
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
-          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
+          # Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTest2Standard:
     name: Action-Test - [2-Standard]
     runs-on: ubuntu-latest
     outputs:
-      outcome: ${{ steps.action-test.outputs.outcome }}
-      conclusion: ${{ steps.action-test.outputs.conclusion }}
+      outcome: ${{ steps.action-test.outcome }}
+      conclusion: ${{ steps.action-test.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -92,17 +92,17 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
-          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+          # Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
 
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
-          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
+          # Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   ActionTestAdvanced:
     name: Action-Test - [3-Advanced]
     runs-on: ubuntu-latest
     outputs:
-      outcome: ${{ steps.action-test.outputs.outcome }}
-      conclusion: ${{ steps.action-test.outputs.conclusion }}
+      outcome: ${{ steps.action-test.outcome }}
+      conclusion: ${{ steps.action-test.conclusion }}
     steps:
       # Need to check out as part of the test, as its a local action
       - name: Checkout repo
@@ -118,10 +118,10 @@ jobs:
         shell: pwsh
         run: |
           Write-Host "Outcome: ${{ steps.action-test.outcome }}"
-          Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
+          # Set-GitHubOutput -Name "outcome" -Value '${{ steps.action-test.outcome }}'
 
           Write-Host "Conclusion: ${{ steps.action-test.conclusion }}"
-          Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
+          # Set-GitHubOutput -Name "conclusion" -Value '${{ steps.action-test.conclusion }}'
 
   CatchJob:
     name: "Catch Job - Aggregate Status"

--- a/action.yml
+++ b/action.yml
@@ -188,6 +188,11 @@ inputs:
       Enable debug mode.
     required: false
     default: 'false'
+  continue-on-error:
+    description: |
+      Continue on error.
+    required: false
+    default: 'false'
 outputs:
   Passed:
     description: Did all tests pass?

--- a/action.yml
+++ b/action.yml
@@ -188,11 +188,6 @@ inputs:
       Enable debug mode.
     required: false
     default: 'false'
-  continue-on-error:
-    description: |
-      Continue on error.
-    required: false
-    default: 'false'
 outputs:
   Passed:
     description: Did all tests pass?
@@ -272,11 +267,9 @@ runs:
 
     - name: Status
       shell: pwsh
-      # if: ${{ inputs.continue-on-error }}
-      env:
-        PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
       run: |
-        Write-Host "Passed: [$env:PASSED]"
-        if ($env:PASSED -ne 'true') {
+        $passed = '${{ fromJSON(steps.test.outputs.result).Passed }}'
+        Write-Host "Passed: [$passed]"
+        if ($passed -ne 'true') {
           exit 1
         }

--- a/action.yml
+++ b/action.yml
@@ -274,7 +274,7 @@ runs:
       shell: pwsh
       if: ${{ inputs.continue-on-error }}
       env:
-        PASSED: ${{ steps.test.outputs.passed }}
+        PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
       run: |
         Write-Host "Passed: [$env:PASSED]"
         if ($env:PASSED -ne 'true') {

--- a/action.yml
+++ b/action.yml
@@ -270,13 +270,13 @@ runs:
         name: ${{ fromJSON(steps.test.outputs.result).TestSuiteName }}-CodeCoverage
         path: ${{ fromJSON(steps.test.outputs.result).CodeCoverageOutputPath }}
 
-    # - name: Status
-    #   shell: pwsh
-    #   if: ${{ inputs.continue-on-error }}
-    #   env:
-    #     PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
-    #   run: |
-    #     Write-Host "Passed: [$env:PASSED]"
-    #     if ($env:PASSED -ne 'true') {
-    #       exit 1
-    #     }
+    - name: Status
+      shell: pwsh
+      # if: ${{ inputs.continue-on-error }}
+      env:
+        PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
+      run: |
+        Write-Host "Passed: [$env:PASSED]"
+        if ($env:PASSED -ne 'true') {
+          exit 1
+        }

--- a/action.yml
+++ b/action.yml
@@ -270,13 +270,13 @@ runs:
         name: ${{ fromJSON(steps.test.outputs.result).TestSuiteName }}-CodeCoverage
         path: ${{ fromJSON(steps.test.outputs.result).CodeCoverageOutputPath }}
 
-    - name: Status
-      shell: pwsh
-      if: ${{ inputs.continue-on-error }}
-      env:
-        PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
-      run: |
-        Write-Host "Passed: [$env:PASSED]"
-        if ($env:PASSED -ne 'true') {
-          exit 1
-        }
+    # - name: Status
+    #   shell: pwsh
+    #   if: ${{ inputs.continue-on-error }}
+    #   env:
+    #     PASSED: ${{ fromJSON(steps.test.outputs.result).Passed }}
+    #   run: |
+    #     Write-Host "Passed: [$env:PASSED]"
+    #     if ($env:PASSED -ne 'true') {
+    #       exit 1
+    #     }

--- a/action.yml
+++ b/action.yml
@@ -264,3 +264,14 @@ runs:
       with:
         name: ${{ fromJSON(steps.test.outputs.result).TestSuiteName }}-CodeCoverage
         path: ${{ fromJSON(steps.test.outputs.result).CodeCoverageOutputPath }}
+
+    - name: Status
+      shell: pwsh
+      if: ${{ inputs.continue-on-error }}
+      env:
+        PASSED: ${{ steps.test.outputs.passed }}
+      run: |
+        Write-Host "Passed: [$env:PASSED]"
+        if ($env:PASSED -ne 'true') {
+          exit 1
+        }

--- a/tests/1-Simple-Failure/Failure.Tests.ps1
+++ b/tests/1-Simple-Failure/Failure.Tests.ps1
@@ -1,0 +1,16 @@
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSReviewUnusedParameter', '',
+    Justification = 'Required for Pester tests'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Required for Pester tests'
+)]
+[CmdletBinding()]
+param()
+
+Describe 'Failure' {
+    It 'True should be false' {
+        $true | Should -Be $false
+    }
+}


### PR DESCRIPTION
## Description

This pull request includes several updates to the GitHub Actions workflow configuration and test files to improve the handling and reporting of test outcomes and conclusions.

Enhancements to GitHub Actions workflow:

* `.github/workflows/Action-Test.yml`
  * Added outputs for `outcome` and `conclusion` to multiple jobs, including `ActionTest1Simple`, `ActionTest1SimpleFailure`, `ActionTest2Standard`, and `ActionTest3Advanced`.
  * Introduced a new job `CatchJob` to aggregate and display the results of all test jobs in a table format, and to check if all jobs passed their expected outcomes and conclusions.

Updates to individual test cases:

* `action.yml`: Added a new step to check the `Passed` status of tests and exit with an error if the tests did not pass, which in turn makes the caller be able to distinguish if the job failed and allows them to act accordingly. We are using this mechanism in the `CatchJob` step of the `Action-Test` workflow to aggregate all status.
* `tests/1-Simple-Failure/Failure.Tests.ps1`: Added a new test case to intentionally fail by asserting that `true` should be `false`, which is required for testing failure scenarios.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
