### PR TITLE
🪲 [Fix]: Align path separator in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -258,7 +258,7 @@ runs:
         Version: ${{ inputs.Version }}
         Script: |
           # Invoke-Pester (pre)
-          ${{ github.action_path }}\scripts\pre.ps1
+          ${{ github.action_path }}/scripts/pre.ps1
 
     - name: Invoke-Pester
       shell: pwsh


### PR DESCRIPTION
## Description

This pull request includes a small change to the `action.yml` file. The change corrects the path format for the `pre.ps1` script from using a backslash to a forward slash.

* Corrected the path format for the `pre.ps1` script in `action.yml` (`${{ github.action_path }}/scripts/pre.ps1`), was '\'.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
