### PR TITLE
🪲 [Fix]: Fix default path for Pester, its workspace now

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,6 @@ inputs:
     description: |
       Path to where tests are located or a configuration file.
     required: false
-    default: tests
   Run_Path:
     description: |
       Directories to be searched for tests, paths directly to test files, or combination of both.

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -176,7 +176,6 @@ LogGroup 'Init - Load configuration' {
 LogGroup 'Init - Export containers' {
     $containers = @()
     $existingContainers = $configuration.Run.Container
-    $configuration.Run.Container = @()
     if ($existingContainers.Count -gt 0) {
         Write-Output "Containers from configuration: [$($existingContainers.Count)]"
         foreach ($existingContainer in $existingContainers) {
@@ -200,6 +199,7 @@ LogGroup 'Init - Export containers' {
             }
         }
     }
+    $configuration.Run.Container = @()
 }
 
 LogGroup 'Init - Export configuration' {


### PR DESCRIPTION
## Description

This pull request includes changes to the `action.yml` and `scripts/init.ps1` files to improve configuration handling and initialization scripts. The most important changes include the removal of a default value in the `action.yml` file and the reordering of container initialization steps in the `scripts/init.ps1` file.

Changes to configuration handling:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L13): Removed the default value for the `Path` input to allow for more flexible test path configurations.

Changes to initialization scripts:

* [`scripts/init.ps1`](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L179): Moved the reinitialization of the `$configuration.Run.Container` array to occur after the existing containers are processed, ensuring that the array is properly reset. [[1]](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L179) [[2]](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6R202)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
