### PR TITLE
🪲 [Fix]: Fix `Path` resolution logic

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -19,7 +19,8 @@ LogGroup 'Init - Get test kit versions' {
 }
 
 LogGroup 'Init - Load inputs' {
-    $providedItem = Resolve-Path -Path "./$env:PSMODULE_INVOKE_PESTER_INPUT_Path" | Select-Object -ExpandProperty Path | Get-Item
+    $path = [string]::IsNullOrEmpty($env:PSMODULE_INVOKE_PESTER_INPUT_Path) ? '.' : $env:PSMODULE_INVOKE_PESTER_INPUT_Path
+    $providedItem = Resolve-Path -Path $path | Select-Object -ExpandProperty Path | Get-Item
     if ($providedItem -is [System.IO.DirectoryInfo]) {
         $providedPath = $providedItem.FullName
     } elseif ($providedItem -is [System.IO.FileInfo]) {


### PR DESCRIPTION
## Description

This pull request includes a change to the `scripts/init.ps1` file to improve the handling of input paths in the `Init - Load inputs` log group.

### Improvements to input path handling

* `scripts/init.ps1`: Modified the `Resolve-Path` command to use a default path of `'.'` if the environment variable `PSMODULE_INVOKE_PESTER_INPUT_Path` is empty. This ensures that the script can handle cases where the input path is not provided.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
