### PR TITLE
🩹 [Patch]: Fix output formatting with Out-String

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -84,11 +84,11 @@ LogGroup 'Init - Load inputs' {
         TestRegistry_Enabled               = $env:PSMODULE_INVOKE_PESTER_INPUT_TestRegistry_Enabled
     }
 
-    [pscustomobject]($inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) }) | Format-List
+    [pscustomobject]($inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) }) | Format-List | Out-String
 }
 
 LogGroup 'Init - Load configuration - Defaults' {
-    Write-Output (New-PesterConfigurationHashtable -Default | Format-Hashtable | Out-String)
+    New-PesterConfigurationHashtable -Default | Format-Hashtable | Out-String
 }
 
 LogGroup 'Init - Load configuration - Custom settings file' {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -20,7 +20,7 @@ $pesterModule = Get-PSResource -Name Pester -Verbose:$false | Sort-Object Versio
 
 '::group::Exec - Import Configuration'
 $configuration = & "$PSScriptRoot/Invoke-Pester.Configuration.ps1"
-$configuration
+$configuration | Out-String
 $configuration.Run.Container = @()
 $containerFiles = Get-ChildItem -Path $PSScriptRoot -Filter *.Container.* -Recurse | Sort-Object FullName
 foreach ($containerFile in $containerFiles) {
@@ -33,7 +33,7 @@ $configuration.Run.Container | ConvertTo-Json
 '::endgroup::'
 
 '::group::Exec - Available modules'
-Get-Module | Format-Table -AutoSize
+Get-Module | Format-Table -AutoSize | Out-String
 '::endgroup::'
 
 $configuration = New-PesterConfiguration -Hashtable $configuration
@@ -62,7 +62,7 @@ LogGroup 'Eval - Test results' {
         exit 1
     }
 
-    $testResults | Format-List
+    $testResults | Format-List | Out-String
 }
 
 LogGroup 'Eval - Test results summary' {
@@ -81,7 +81,7 @@ LogGroup 'Eval - Set outputs' {
         TestResultOutputPath   = $testResults.Configuration.TestResult.OutputPath.Value
         CodeCoverageEnabled    = $testResults.Configuration.CodeCoverage.Enabled.Value
         CodeCoverageOutputPath = $testResults.Configuration.CodeCoverage.OutputPath.Value
-    } | Format-List
+    } | Format-List | Out-String
 }
 
 LogGroup 'Exit' {


### PR DESCRIPTION
## Description

This pull request includes multiple changes to the PowerShell scripts to ensure that formatted output is converted to strings.

### Changes to ensure formatted output is converted to strings

* Added `Out-String` to the `Format-List` and `Format-Table` commands to avoid getting text wrapped or cut of.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
