### PR TITLE
🩹 [Patch]: Improve input filtering logic in initialization script

### DIFF
--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -900,3 +900,40 @@ filter Set-PesterReportRunSummary {
         }
     }
 }
+
+filter Show-Input {
+    <#
+        .SYNOPSIS
+        Displays a formatted representation of a hashtable.
+
+        .DESCRIPTION
+        This function takes a hashtable as input and formats it into a structured output.
+
+        .EXAMPLE
+        Show-Input -Inputs @{ Key1 = 'Value1'; Key2 = 'Value2' }
+
+        .OUTPUTS
+        string
+
+        .NOTES
+        Returns a formatted string representation of the input hashtable.
+    #>
+    [outputType([string])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [hashtable] $Inputs
+    )
+
+    $new = [pscustomobject]@{}
+    $Inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) } | ForEach-Object {
+        $name = $_.Key
+        $value = $_.Value
+        if ($value -is [string]) {
+            $new | Add-Member -MemberType NoteProperty -Name $name -Value $value
+        } elseif ($value -is [array]) {
+            $new | Add-Member -MemberType NoteProperty -Name $name -Value ($value -join ', ')
+        }
+    }
+    [pscustomobject]$new | Format-List | Out-String
+}

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -84,7 +84,7 @@ LogGroup 'Init - Load inputs' {
         TestRegistry_Enabled               = $env:PSMODULE_INVOKE_PESTER_INPUT_TestRegistry_Enabled
     }
 
-    Show-Inputs -Inputs $inputs
+    Show-Input -Inputs $inputs
 }
 
 LogGroup 'Init - Load configuration - Defaults' {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -84,7 +84,8 @@ LogGroup 'Init - Load inputs' {
         TestRegistry_Enabled               = $env:PSMODULE_INVOKE_PESTER_INPUT_TestRegistry_Enabled
     }
 
-    [pscustomobject]($inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) }) | Format-List | Out-String
+    $new = $inputs | Where-Object { -not [string]::IsNullOrEmpty($_.Value) }
+    [pscustomobject]$new | Format-List | Out-String
 }
 
 LogGroup 'Init - Load configuration - Defaults' {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -84,7 +84,16 @@ LogGroup 'Init - Load inputs' {
         TestRegistry_Enabled               = $env:PSMODULE_INVOKE_PESTER_INPUT_TestRegistry_Enabled
     }
 
-    $new = $inputs | Where-Object { -not [string]::IsNullOrEmpty($_.Value) }
+    $new = [pscustomobject]@{}
+    $inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) } | ForEach-Object {
+        $name = $_.Key
+        $value = $_.Value
+        if ($value -is [string]) {
+            $new | Add-Member -MemberType NoteProperty -Name $name -Value $value
+        } elseif ($value -is [array]) {
+            $new | Add-Member -MemberType NoteProperty -Name $name -Value ($value -join ', ')
+        }
+    }
     [pscustomobject]$new | Format-List | Out-String
 }
 

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -15,7 +15,7 @@ LogGroup 'Init - Get test kit versions' {
     [PSCustomObject]@{
         PowerShell = $PSVersionTable.PSVersion.ToString()
         Pester     = $pesterModule.Version
-    } | Format-List
+    } | Format-List | Out-String
 }
 
 LogGroup 'Init - Load inputs' {
@@ -84,17 +84,7 @@ LogGroup 'Init - Load inputs' {
         TestRegistry_Enabled               = $env:PSMODULE_INVOKE_PESTER_INPUT_TestRegistry_Enabled
     }
 
-    $new = [pscustomobject]@{}
-    $inputs.GetEnumerator() | Where-Object { -not [string]::IsNullOrEmpty($_.Value) } | ForEach-Object {
-        $name = $_.Key
-        $value = $_.Value
-        if ($value -is [string]) {
-            $new | Add-Member -MemberType NoteProperty -Name $name -Value $value
-        } elseif ($value -is [array]) {
-            $new | Add-Member -MemberType NoteProperty -Name $name -Value ($value -join ', ')
-        }
-    }
-    [pscustomobject]$new | Format-List | Out-String
+    Show-Inputs -Inputs $inputs
 }
 
 LogGroup 'Init - Load configuration - Defaults' {

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -1,6 +1,8 @@
 ﻿[CmdletBinding()]
 param()
 
+$PSStyle.OutputRendering = 'Ansi'
+
 '::group::Exec - Setup prerequisites'
 'Pester' | ForEach-Object {
     Install-PSResource -Name $_ -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery


### PR DESCRIPTION
## Description

This pull request introduces a new filter function and makes some improvements to existing logging and input handling in PowerShell scripts.

### New filter function

* Added `Show-Input` filter to `scripts/Helpers.psm1` to format and display hashtable inputs in a structured output.

### Improvements to logging and input handling

* Updated `scripts/init.ps1` to use `Out-String` with `Format-List` for better logging output.
* Replaced inline formatting with `Show-Input` filter for input handling in `scripts/init.ps1`.

### Configuration changes

* Set `$PSStyle.OutputRendering` to 'Ansi' in `scripts/main.ps1` to ensure consistent output rendering style.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
