### PR TITLE
🩹 [Patch]: Remove forced `-Verbose` flag

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -195,7 +195,7 @@ LogGroup 'Init - Export containers' {
             $containerFileName = $containerFile | Split-Path -Leaf
             LogGroup "Init - Export containers - $containerFileName" {
                 Format-Hashtable -Hashtable $container
-                Write-Verbose 'Converting hashtable to PesterContainer' -Verbose
+                Write-Verbose 'Converting hashtable to PesterContainer'
                 Export-Hashtable -Hashtable $container -Path "$PSScriptRoot/$containerFileName"
             }
         }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -27,8 +27,8 @@ $configuration.Run.Container = @()
 $containerFiles = Get-ChildItem -Path $PSScriptRoot -Filter *.Container.* -Recurse | Sort-Object FullName
 foreach ($containerFile in $containerFiles) {
     $container = & $($containerFile.FullName)
-    Write-Verbose "Processing container [$container]" -Verbose
-    Write-Verbose 'Converting hashtable to PesterContainer' -Verbose
+    Write-Verbose "Processing container [$container]"
+    Write-Verbose 'Converting hashtable to PesterContainer'
     $configuration.Run.Container += New-PesterContainer @container
 }
 $configuration.Run.Container | ConvertTo-Json


### PR DESCRIPTION
## Description

This pull request includes minor changes to improve the logging output in the PowerShell scripts `init.ps1` and `main.ps1`. The changes focus on removing the redundant `-Verbose` parameter from `Write-Verbose` cmdlets.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
