### PR TITLE
🩹 [Patch]: Simplify path handling

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -20,18 +20,18 @@ LogGroup 'Init - Get test kit versions' {
 
 LogGroup 'Init - Load inputs' {
     $path = [string]::IsNullOrEmpty($env:PSMODULE_INVOKE_PESTER_INPUT_Path) ? '.' : $env:PSMODULE_INVOKE_PESTER_INPUT_Path
-    $providedItem = Resolve-Path -Path $path | Select-Object -ExpandProperty Path | Get-Item
-    if ($providedItem -is [System.IO.DirectoryInfo]) {
-        $providedPath = $providedItem.FullName
-    } elseif ($providedItem -is [System.IO.FileInfo]) {
-        $providedPath = $providedItem.Directory.FullName
-    } else {
-        Write-GitHubError "❌ Provided path [$providedItem] is not a valid directory or file."
-        exit 1
-    }
+    # $providedItem = Resolve-Path -Path $path | Select-Object -ExpandProperty Path | Get-Item
+    # if ($providedItem -is [System.IO.DirectoryInfo]) {
+    #     $providedPath = $providedItem.FullName
+    # } elseif ($providedItem -is [System.IO.FileInfo]) {
+    #     $providedPath = $providedItem.Directory.FullName
+    # } else {
+    #     Write-GitHubError "❌ Provided path [$providedItem] is not a valid directory or file."
+    #     exit 1
+    # }
 
     $inputs = @{
-        Path                               = $providedPath
+        Path                               = $path
 
         Run_Path                           = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
         Run_ExcludePath                    = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_ExcludePath


### PR DESCRIPTION
## Description

This pull request includes changes to the `scripts/init.ps1` file, specifically within the `LogGroup 'Init - Load inputs'` block. The changes primarily involve removing the code that resolves and validates the provided path, simplifying the assignment of the `Path` input.

Simplification of path resolution and validation:

* Removed the code that resolves the provided path.
* Directly assigned the `Path` input to the `$path` variable without additional validation.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
