### PR TITLE
🩹 [Patch]: Update output paths in initialization script to use absolute paths

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -219,8 +219,8 @@ LogGroup 'Init - Export containers' {
 
 LogGroup 'Init - Export configuration' {
     $artifactName = $configuration.TestResult.TestSuiteName ?? 'Pester'
-    $configuration.TestResult.OutputPath = "test_reports/$artifactName-TestResult-Report.xml"
-    $configuration.CodeCoverage.OutputPath = "test_reports/$artifactName-CodeCoverage-Report.xml"
+    $configuration.TestResult.OutputPath = "$pwd/test_reports/$artifactName-TestResult-Report.xml"
+    $configuration.CodeCoverage.OutputPath = "$pwd/test_reports/$artifactName-CodeCoverage-Report.xml"
     $configuration.Run.PassThru = $true
 
     Format-Hashtable -Hashtable $configuration


### PR DESCRIPTION
## Description

This pull request includes a change to the `scripts/init.ps1` file to modify the paths for test result and code coverage report outputs.

* `scripts/init.ps1`:
  * Updated the `TestResult.OutputPath` and `CodeCoverage.OutputPath` to use the current working directory (`$pwd`) for generating test reports, aligning with the use of `WorkingDirectory`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
