### PR TITLE
🪲 [Fix]: Fix coverage percent target handling when not provided

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -115,7 +115,8 @@ LogGroup 'Init - Load configuration - Action overrides' {
             Path                  = $inputs.CodeCoverage_Path
             ExcludeTests          = [string]::IsNullOrEmpty($inputs.CodeCoverage_ExcludeTests) ? $null : $inputs.CodeCoverage_ExcludeTests -eq 'true'
             RecursePaths          = [string]::IsNullOrEmpty($inputs.CodeCoverage_RecursePaths) ? $null : $inputs.CodeCoverage_RecursePaths -eq 'true'
-            CoveragePercentTarget = [decimal]$inputs.CodeCoverage_CoveragePercentTarget
+            CoveragePercentTarget = [string]::IsNullOrEmpty($inputs.CodeCoverage_CoveragePercentTarget) ?
+            $null : [decimal]$inputs.CodeCoverage_CoveragePercentTarget
             UseBreakpoints        = [string]::IsNullOrEmpty($inputs.CodeCoverage_UseBreakpoints) ?
             $null : $inputs.CodeCoverage_UseBreakpoints -eq 'true'
             SingleHitBreakpoints  = [string]::IsNullOrEmpty($inputs.CodeCoverage_SingleHitBreakpoints) ?


### PR DESCRIPTION
## Description

This pull request includes a small change to the `scripts/init.ps1` file. The change ensures that the `CoveragePercentTarget` parameter is properly checked for null or empty values before being cast to a decimal.

* [`scripts/init.ps1`](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L118-R119): Modified the assignment of `CoveragePercentTarget` to include a check for null or empty values before casting to a decimal.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
