### PR TITLE
🌟 [Breaking change]: Cleanup `StepSummary` inputs

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -230,7 +230,7 @@ jobs:
                 Write-Output "Installing module: $name"
                 $retryCount = 5
                 $retryDelay = 10
-                for ($i -lt $retryCount; $i++) {
+                for ($i = 0; $i -lt $retryCount; $i++) {
                     try {
                         Install-PSResource -Name $name -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery
                         break

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -64,6 +64,7 @@ jobs:
         with:
           WorkingDirectory: tests/1-Simple-Failure
           StepSummary_Mode: Full
+          StepSummary_ShowTestOverview: true
 
       - name: Status
         shell: pwsh
@@ -92,6 +93,7 @@ jobs:
         with:
           WorkingDirectory: tests/1-Simple-Failure
           TestResult_TestSuiteName: 1-Simple-Failure
+          StepSummary_ShowConfiguration: true
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -201,6 +201,7 @@ jobs:
         with:
           Path: Pester.Configuration.ps1
           WorkingDirectory: tests/3-Advanced
+          StepSummary_Mode: None
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -63,8 +63,7 @@ jobs:
         continue-on-error: true
         with:
           WorkingDirectory: tests/1-Simple-Failure
-          StepSummary_Enabled: true
-          StepSummary_ShowTests: Full
+          StepSummary_Mode: Full
 
       - name: Status
         shell: pwsh
@@ -93,7 +92,6 @@ jobs:
         with:
           WorkingDirectory: tests/1-Simple-Failure
           TestResult_TestSuiteName: 1-Simple-Failure
-          StepSummary_Enabled: true
 
       - name: Status
         shell: pwsh
@@ -148,8 +146,6 @@ jobs:
         with:
           WorkingDirectory: tests/2-Standard
           Output_CIFormat: GithubActions
-          StepSummary_Enabled: true
-          StepSummary_ShowTests: Failed
 
       - name: Status
         shell: pwsh
@@ -234,7 +230,7 @@ jobs:
                 Write-Output "Installing module: $name"
                 $retryCount = 5
                 $retryDelay = 10
-                for ($i = 0; $i -lt $retryCount; $i++) {
+                for ($i -lt $retryCount; $i++) {
                     try {
                         Install-PSResource -Name $name -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery
                         break

--- a/README.md
+++ b/README.md
@@ -263,9 +263,8 @@ jobs:
 |--------------------------------------|--------------------------------------------------------------------------------------------------------|-------------|
 | `Path`                               | Path to where tests are located or a configuration file.                                               | *(none)*    |
 | `ReportAsJson`                       | Output generated reports in JSON format in addition to the configured format through Pester.           | `true`      |
-| `StepSummary_Enabled`                | Controls if a GitHub step summary should be shown.                                                     | `false`     |
-| `StepSummary_ShowTestOverview`       | Controls whether to show the test overview table in the GitHub step summary.                           | `true`      |
-| `StepSummary_ShowTests`              | Controls which tests to show in the GitHub step summary. Allows "Full", "Failed", or "None".           | `Failed`    |
+| `StepSummary_Mode`                   | Controls which tests to show in the GitHub step summary. Allows "Full" (all tests), "Failed" (only failed tests), or "None" (disable step summary). | `Failed`    |
+| `StepSummary_ShowTestOverview`       | Controls whether to show the test overview table in the GitHub step summary.                           | `false`     |
 | `StepSummary_ShowConfiguration`      | Controls whether to show the configuration details in the GitHub step summary.                         | `false`     |
 | `Run_Path`                           | Directories/files to be searched for tests.                                                            | *(none)*    |
 | `Run_ExcludePath`                    | Directories/files to exclude from the run.                                                             | *(none)*    |

--- a/action.yml
+++ b/action.yml
@@ -15,21 +15,16 @@ inputs:
       Output generated reports in JSON format in addition to the configured format through Pester.
     required: false
     default: 'true'
-  StepSummary_Enabled:
+  StepSummary_Mode:
     description: |
-      Controls if a GitHub step summary should be shown.
+      Controls which tests to show in the GitHub step summary. Allows "Full" (show all tests), "Failed" (only failed tests), or "None" (disable step summary).
     required: false
-    default: 'false'
+    default: 'Failed'
   StepSummary_ShowTestOverview:
     description: |
       Controls whether to show the test overview table in the GitHub step summary.
     required: false
-    default: 'true'
-  StepSummary_ShowTests:
-    description: |
-      Controls which tests to show in the GitHub step summary. Allows "Full", "Failed", or "None".
-    required: false
-    default: 'Failed'
+    default: 'false'
   StepSummary_ShowConfiguration:
     description: |
       Controls whether to show the configuration details in the GitHub step summary.
@@ -344,9 +339,8 @@ runs:
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
         PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson: ${{ inputs.ReportAsJson }}
-        PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Enabled: ${{ inputs.StepSummary_Enabled }}
+        PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode: ${{ inputs.StepSummary_Mode }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview: ${{ inputs.StepSummary_ShowTestOverview }}
-        PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTests: ${{ inputs.StepSummary_ShowTests }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration: ${{ inputs.StepSummary_ShowConfiguration }}
       id: test
       run: |

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -858,8 +858,6 @@ filter Set-PesterReportSummary {
         $testTree = $testResults.Containers | Set-PesterReportTestsSummary -FailedOnly:$showOnlyFailed
     }
 
-    '----'
-
     # Show configuration if enabled
     if ($ShowConfiguration) {
         $configOverview = $testResults | Set-PesterReportConfigurationSummary
@@ -869,10 +867,10 @@ filter Set-PesterReportSummary {
         -not [string]::IsNullOrEmpty($configOverview)) {
 
         Details "$testSuitStatusIcon - $testSuitName ($formattedTestDuration)" {
-            $tableOverview
-            $testTree
+            $tableOverview | Out-String
+            $testTree | Out-String
             '----'
-            $configOverview
+            $configOverview | Out-String
         }
     }
 }

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -847,23 +847,32 @@ filter Set-PesterReportSummary {
     $testSuitStatusIcon = $statusIcon[$TestResults.Result]
     $formattedTestDuration = $testResults.Duration | Format-TimeSpan
 
-    Details "$testSuitStatusIcon - $testSuitName ($formattedTestDuration)" {
-        # Show test overview table if enabled
-        if ($ShowTestOverview) {
-            $testResults | Set-PesterReportSummaryTable
-        }
+    # Show test overview table if enabled
+    if ($ShowTestOverview) {
+        $tableOverview = $testResults | Set-PesterReportSummaryTable
+    }
 
-        # Show tests based on the specified mode
-        if ($ShowTestsMode -ne 'None') {
-            $showOnlyFailed = $ShowTestsMode -eq 'Failed'
-            $testResults.Containers | Set-PesterReportTestsSummary -FailedOnly:$showOnlyFailed
-        }
+    # Show tests based on the specified mode
+    if ($ShowTestsMode -ne 'None') {
+        $showOnlyFailed = $ShowTestsMode -eq 'Failed'
+        $testTree = $testResults.Containers | Set-PesterReportTestsSummary -FailedOnly:$showOnlyFailed
+    }
 
-        '----'
+    '----'
 
-        # Show configuration if enabled
-        if ($ShowConfiguration) {
-            $testResults | Set-PesterReportConfigurationSummary
+    # Show configuration if enabled
+    if ($ShowConfiguration) {
+        $configOverview = $testResults | Set-PesterReportConfigurationSummary
+    }
+    if (-not [string]::IsNullOrEmpty($tableOverview) -or
+        -not [string]::IsNullOrEmpty($testTree) -or
+        -not [string]::IsNullOrEmpty($configOverview)) {
+
+        Details "$testSuitStatusIcon - $testSuitName ($formattedTestDuration)" {
+            $tableOverview
+            $testTree
+            '----'
+            $configOverview
         }
     }
 }

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -832,7 +832,7 @@ filter Set-PesterReportSummary {
 
         # Controls whether to show the test overview table in the summary.
         [Parameter()]
-        [bool] $ShowTestOverview = $true,
+        [bool] $ShowTestOverview = $false,
 
         # Controls which tests to show in the summary. Allows "Full", "Failed", or "None".
         [Parameter()]

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -862,10 +862,8 @@ filter Set-PesterReportSummary {
     if ($ShowConfiguration) {
         $configOverview = $testResults | Set-PesterReportConfigurationSummary
     }
-    if (-not [string]::IsNullOrEmpty($tableOverview) -or
-        -not [string]::IsNullOrEmpty($testTree) -or
-        -not [string]::IsNullOrEmpty($configOverview)) {
 
+    if ($tableOverview -or $testTree -or $configOverview) {
         Details "$testSuitStatusIcon - $testSuitName ($formattedTestDuration)" {
             $tableOverview | Out-String
             $testTree | Out-String

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -94,8 +94,13 @@ LogGroup 'Eval - Test results summary' {
             ShowConfiguration = $showConfiguration
         }
         [PSCustomObject]$summaryParams | Format-List | Out-String
+        $content = $testResults | Set-PesterReportSummary @summaryParams
 
-        Set-GitHubStepSummary -Summary ($testResults | Set-PesterReportSummary @summaryParams)
+        if ($content) {
+            Set-GitHubStepSummary -Summary $content
+        } else {
+            Write-Verbose 'No content to display in step summary'
+        }
         $PSStyle.OutputRendering = 'Ansi'
     } else {
         Write-Verbose 'Step summary has been disabled or no components are configured for display'

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -77,24 +77,28 @@ LogGroup 'Eval - Test results' {
 }
 
 LogGroup 'Eval - Test results summary' {
-    $stepSummaryEnabled = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Enabled -eq 'true'
-    $showTestOverview = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview -ne 'false'
-    $showTests = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTests
+    $stepSummaryMode = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode
+    $showTestOverview = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview -eq 'true'
     $showConfiguration = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration -eq 'true'
 
-    if ($stepSummaryEnabled) {
+    # Only generate a step summary if the StepSummary setting is not 'None'
+    # AND at least one component is configured to be displayed
+    $generateSummary = $showTestOverview -or $showConfiguration -or ($stepSummaryMode -in @('Failed', 'Full'))
+
+    if ($generateSummary) {
         $PSStyle.OutputRendering = 'Host'
 
         $summaryParams = @{
             ShowTestOverview  = $showTestOverview
-            ShowTestsMode     = $showTests
+            ShowTestsMode     = $stepSummaryMode
             ShowConfiguration = $showConfiguration
         }
+        [PSCustomObject]$summaryParams | Format-List | Out-String
 
         Set-GitHubStepSummary -Summary ($testResults | Set-PesterReportSummary @summaryParams)
         $PSStyle.OutputRendering = 'Ansi'
     } else {
-        Write-Verbose 'Step summary has been disabled'
+        Write-Verbose 'Step summary has been disabled or no components are configured for display'
     }
 }
 


### PR DESCRIPTION
## Description

This pull request includes several changes to improve the configuration and functionality of the GitHub step summary in the Pester testing framework. The most important changes include the consolidation of step summary controls into a single mode parameter, updates to default values, and improvements to the logic for generating summaries.

Changes to step summary controls:

* 🌟 Consolidated `StepSummary_Enabled` and `StepSummary_ShowTests` into a single `StepSummary_Mode` parameter, which controls which tests to show in the GitHub step summary. The allowed values are:
  * "Full" (show all tests)
  * "Failed" (only failed tests)
  * "None" (disable step summary).

Updates to default values:

* Changed the default value of `StepSummary_ShowTestOverview` to `false` in both `action.yml` and `scripts/Helpers.psm1`.

Improvements to summary generation logic:

* Updated the logic in `scripts/exec.ps1` to only generate a step summary if the `StepSummary_Mode` is not set to 'None' and at least one component (test overview or configuration) is configured to be displayed.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [x] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
