### PR TITLE
🩹 [Patch]: Remove dependency on the `GitHub` module

### DIFF
--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -69,7 +69,7 @@ $pesterModule = Get-PSResource -Name Pester -Verbose:$false | Sort-Object Versio
 
 '::group::Eval - Test results'
 if ($null -eq $testResults) {
-    Write-GitHubError '❌ No test results were returned.'
+    '::error::❌ No test results were returned.'
     exit 1
 }
 

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -107,57 +107,57 @@ if ($generateSummary) {
 }
 '::endgroup::'
 
-'::group::Eval - Set outputs' {
-    $testResultOutputFolderPath = $testResults.Configuration.TestResult.OutputPath.Value | Split-Path -Parent
-    $codeCoverageOutputFolderPath = $testResults.Configuration.CodeCoverage.OutputPath.Value | Split-Path -Parent
-    [pscustomobject]@{
-        TestSuiteName          = $testResults.Configuration.TestResult.TestSuiteName.Value
-        TestResultEnabled      = $testResults.Configuration.TestResult.Enabled.Value
-        TestResultOutputPath   = $testResultOutputFolderPath
-        CodeCoverageEnabled    = $testResults.Configuration.CodeCoverage.Enabled.Value
-        CodeCoverageOutputPath = $codeCoverageOutputFolderPath
-    } | Format-List | Out-String
-    "TestSuiteName=$($testResults.Configuration.TestResult.TestSuiteName.Value)" >> $env:GITHUB_OUTPUT
-    "TestResultEnabled=$($testResults.Configuration.TestResult.Enabled.Value)" >> $env:GITHUB_OUTPUT
-    "TestResultOutputPath=$($testResultOutputFolderPath)" >> $env:GITHUB_OUTPUT
-    "CodeCoverageEnabled=$($testResults.Configuration.CodeCoverage.Enabled.Value)" >> $env:GITHUB_OUTPUT
-    "CodeCoverageOutputPath=$($codeCoverageOutputFolderPath)" >> $env:GITHUB_OUTPUT
-    "Executed=$($testResults.Executed)" >> $env:GITHUB_OUTPUT
-    "Result=$($testResults.Result)" >> $env:GITHUB_OUTPUT
-    "FailedCount=$($testResults.FailedCount)" >> $env:GITHUB_OUTPUT
-    "FailedBlocksCount=$($testResults.FailedBlocksCount)" >> $env:GITHUB_OUTPUT
-    "FailedContainersCount=$($testResults.FailedContainersCount)" >> $env:GITHUB_OUTPUT
-    "PassedCount=$($testResults.PassedCount)" >> $env:GITHUB_OUTPUT
-    "SkippedCount=$($testResults.SkippedCount)" >> $env:GITHUB_OUTPUT
-    "InconclusiveCount=$($testResults.InconclusiveCount)" >> $env:GITHUB_OUTPUT
-    "NotRunCount=$($testResults.NotRunCount)" >> $env:GITHUB_OUTPUT
-    "TotalCount=$($testResults.TotalCount)" >> $env:GITHUB_OUTPUT
+'::group::Eval - Set outputs'
+$testResultOutputFolderPath = $testResults.Configuration.TestResult.OutputPath.Value | Split-Path -Parent
+$codeCoverageOutputFolderPath = $testResults.Configuration.CodeCoverage.OutputPath.Value | Split-Path -Parent
+[pscustomobject]@{
+    TestSuiteName          = $testResults.Configuration.TestResult.TestSuiteName.Value
+    TestResultEnabled      = $testResults.Configuration.TestResult.Enabled.Value
+    TestResultOutputPath   = $testResultOutputFolderPath
+    CodeCoverageEnabled    = $testResults.Configuration.CodeCoverage.Enabled.Value
+    CodeCoverageOutputPath = $codeCoverageOutputFolderPath
+} | Format-List | Out-String
+"TestSuiteName=$($testResults.Configuration.TestResult.TestSuiteName.Value)" >> $env:GITHUB_OUTPUT
+"TestResultEnabled=$($testResults.Configuration.TestResult.Enabled.Value)" >> $env:GITHUB_OUTPUT
+"TestResultOutputPath=$($testResultOutputFolderPath)" >> $env:GITHUB_OUTPUT
+"CodeCoverageEnabled=$($testResults.Configuration.CodeCoverage.Enabled.Value)" >> $env:GITHUB_OUTPUT
+"CodeCoverageOutputPath=$($codeCoverageOutputFolderPath)" >> $env:GITHUB_OUTPUT
+"Executed=$($testResults.Executed)" >> $env:GITHUB_OUTPUT
+"Result=$($testResults.Result)" >> $env:GITHUB_OUTPUT
+"FailedCount=$($testResults.FailedCount)" >> $env:GITHUB_OUTPUT
+"FailedBlocksCount=$($testResults.FailedBlocksCount)" >> $env:GITHUB_OUTPUT
+"FailedContainersCount=$($testResults.FailedContainersCount)" >> $env:GITHUB_OUTPUT
+"PassedCount=$($testResults.PassedCount)" >> $env:GITHUB_OUTPUT
+"SkippedCount=$($testResults.SkippedCount)" >> $env:GITHUB_OUTPUT
+"InconclusiveCount=$($testResults.InconclusiveCount)" >> $env:GITHUB_OUTPUT
+"NotRunCount=$($testResults.NotRunCount)" >> $env:GITHUB_OUTPUT
+"TotalCount=$($testResults.TotalCount)" >> $env:GITHUB_OUTPUT
 
-    if ($env:PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson -eq 'true' -and $testResults.Configuration.TestResult.Enabled.Value) {
-        $jsonOutputPath = $testResults.Configuration.TestResult.OutputPath.Value -Replace '\.xml$', '.json'
-        Write-Output "Exporting test results to [$jsonOutputPath]"
-        $testResults | Get-PesterTestTree | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $jsonOutputPath
-    }
+if ($env:PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson -eq 'true' -and $testResults.Configuration.TestResult.Enabled.Value) {
+    $jsonOutputPath = $testResults.Configuration.TestResult.OutputPath.Value -Replace '\.xml$', '.json'
+    Write-Output "Exporting test results to [$jsonOutputPath]"
+    $testResults | Get-PesterTestTree | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $jsonOutputPath
+}
 
-    if ($env:PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson -eq 'true' -and $testResults.Configuration.CodeCoverage.Enabled.Value) {
-        $jsonOutputPath = $testResults.Configuration.CodeCoverage.OutputPath.Value -Replace '\.xml$', '.json'
-        Write-Output "Exporting code coverage results to [$jsonOutputPath]"
-        $testResults.CodeCoverage | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $jsonOutputPath
-    }
-    '::endgroup::'
+if ($env:PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson -eq 'true' -and $testResults.Configuration.CodeCoverage.Enabled.Value) {
+    $jsonOutputPath = $testResults.Configuration.CodeCoverage.OutputPath.Value -Replace '\.xml$', '.json'
+    Write-Output "Exporting code coverage results to [$jsonOutputPath]"
+    $testResults.CodeCoverage | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $jsonOutputPath
+}
+'::endgroup::'
 
-    '::group::Exit'
-    if ($testResults.Result -eq 'Passed') {
-        '::notice::✅ All tests passed.'
-        $script:exit = 0
+'::group::Exit'
+if ($testResults.Result -eq 'Passed') {
+    '::notice::✅ All tests passed.'
+    $script:exit = 0
+} else {
+    if ($failedTests -gt 0) {
+        "::error::❌ Some [$failedTests] tests failed."
+        $script:exit = $failedTests
     } else {
-        if ($failedTests -gt 0) {
-            "::error::❌ Some [$failedTests] tests failed."
-            $script:exit = $failedTests
-        } else {
-            '::error::❌ Some tests failed.'
-            $script:exit = 1
-        }
+        '::error::❌ Some tests failed.'
+        $script:exit = 1
     }
+}
 
-    exit $script:exit
+exit $script:exit

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -54,60 +54,60 @@ Get-Module | Format-Table -AutoSize | Out-String
 $configuration = New-PesterConfiguration -Hashtable $configuration
 $testResults = Invoke-Pester -Configuration $configuration
 
-LogGroup 'Eval - Setup prerequisites' {
-    'Pester', 'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
+'::group::Eval - Setup prerequisites'
+'Pester', 'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
+'::endgroup::'
+
+'::group::Eval - Get test kit versions'
+$pesterModule = Get-PSResource -Name Pester -Verbose:$false | Sort-Object Version -Descending | Select-Object -First 1
+
+[PSCustomObject]@{
+    PowerShell = $PSVersionTable.PSVersion.ToString()
+    Pester     = $pesterModule.Version
+} | Format-List
+'::endgroup::'
+
+'::group::Eval - Test results'
+if ($null -eq $testResults) {
+    Write-GitHubError '❌ No test results were returned.'
+    exit 1
 }
 
-LogGroup 'Eval - Get test kit versions' {
-    $pesterModule = Get-PSResource -Name Pester -Verbose:$false | Sort-Object Version -Descending | Select-Object -First 1
+$testResults | Format-List | Out-String
+'::endgroup::'
 
-    [PSCustomObject]@{
-        PowerShell = $PSVersionTable.PSVersion.ToString()
-        Pester     = $pesterModule.Version
-    } | Format-List
-}
+'::group::Eval - Test results summary'
+$stepSummaryMode = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode
+$showTestOverview = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview -eq 'true'
+$showConfiguration = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration -eq 'true'
 
-LogGroup 'Eval - Test results' {
-    if ($null -eq $testResults) {
-        Write-GitHubError '❌ No test results were returned.'
-        exit 1
+# Only generate a step summary if the StepSummary setting is not 'None'
+# AND at least one component is configured to be displayed
+$generateSummary = $showTestOverview -or $showConfiguration -or ($stepSummaryMode -in @('Failed', 'Full'))
+
+if ($generateSummary) {
+    $PSStyle.OutputRendering = 'Host'
+
+    $summaryParams = @{
+        ShowTestOverview  = $showTestOverview
+        ShowTestsMode     = $stepSummaryMode
+        ShowConfiguration = $showConfiguration
     }
+    [PSCustomObject]$summaryParams | Format-List | Out-String
+    $content = $testResults | Set-PesterReportSummary @summaryParams
 
-    $testResults | Format-List | Out-String
-}
-
-LogGroup 'Eval - Test results summary' {
-    $stepSummaryMode = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode
-    $showTestOverview = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview -eq 'true'
-    $showConfiguration = $env:PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration -eq 'true'
-
-    # Only generate a step summary if the StepSummary setting is not 'None'
-    # AND at least one component is configured to be displayed
-    $generateSummary = $showTestOverview -or $showConfiguration -or ($stepSummaryMode -in @('Failed', 'Full'))
-
-    if ($generateSummary) {
-        $PSStyle.OutputRendering = 'Host'
-
-        $summaryParams = @{
-            ShowTestOverview  = $showTestOverview
-            ShowTestsMode     = $stepSummaryMode
-            ShowConfiguration = $showConfiguration
-        }
-        [PSCustomObject]$summaryParams | Format-List | Out-String
-        $content = $testResults | Set-PesterReportSummary @summaryParams
-
-        if ($content) {
-            Set-GitHubStepSummary -Summary $content
-        } else {
-            Write-Verbose 'No content to display in step summary'
-        }
-        $PSStyle.OutputRendering = 'Ansi'
+    if ($content) {
+        $content >> $env:GITHUB_STEP_SUMMARY
     } else {
-        Write-Verbose 'Step summary has been disabled or no components are configured for display'
+        Write-Verbose 'No content to display in step summary'
     }
+    $PSStyle.OutputRendering = 'Ansi'
+} else {
+    Write-Verbose 'Step summary has been disabled or no components are configured for display'
 }
+'::endgroup::'
 
-LogGroup 'Eval - Set outputs' {
+'::group::Eval - Set outputs' {
     $testResultOutputFolderPath = $testResults.Configuration.TestResult.OutputPath.Value | Split-Path -Parent
     $codeCoverageOutputFolderPath = $testResults.Configuration.CodeCoverage.OutputPath.Value | Split-Path -Parent
     [pscustomobject]@{
@@ -117,21 +117,21 @@ LogGroup 'Eval - Set outputs' {
         CodeCoverageEnabled    = $testResults.Configuration.CodeCoverage.Enabled.Value
         CodeCoverageOutputPath = $codeCoverageOutputFolderPath
     } | Format-List | Out-String
-    Set-GitHubOutput -Name 'TestSuiteName' -Value $testResults.Configuration.TestResult.TestSuiteName.Value
-    Set-GitHubOutput -Name 'TestResultEnabled' -Value $testResults.Configuration.TestResult.Enabled.Value
-    Set-GitHubOutput -Name 'TestResultOutputPath' -Value $testResultOutputFolderPath
-    Set-GitHubOutput -Name 'CodeCoverageEnabled' -Value $testResults.Configuration.CodeCoverage.Enabled.Value
-    Set-GitHubOutput -Name 'CodeCoverageOutputPath' -Value $codeCoverageOutputFolderPath
-    Set-GitHubOutput -Name 'Executed' -Value $testResults.Executed
-    Set-GitHubOutput -Name 'Result' -Value $testResults.Result
-    Set-GitHubOutput -Name 'FailedCount' -Value $testResults.FailedCount
-    Set-GitHubOutput -Name 'FailedBlocksCount' -Value $testResults.FailedBlocksCount
-    Set-GitHubOutput -Name 'FailedContainersCount' -Value $testResults.FailedContainersCount
-    Set-GitHubOutput -Name 'PassedCount' -Value $testResults.PassedCount
-    Set-GitHubOutput -Name 'SkippedCount' -Value $testResults.SkippedCount
-    Set-GitHubOutput -Name 'InconclusiveCount' -Value $testResults.InconclusiveCount
-    Set-GitHubOutput -Name 'NotRunCount' -Value $testResults.NotRunCount
-    Set-GitHubOutput -Name 'TotalCount' -Value $testResults.TotalCount
+    "TestSuiteName=$($testResults.Configuration.TestResult.TestSuiteName.Value)" >> $env:GITHUB_OUTPUT
+    "TestResultEnabled=$($testResults.Configuration.TestResult.Enabled.Value)" >> $env:GITHUB_OUTPUT
+    "TestResultOutputPath=$($testResultOutputFolderPath)" >> $env:GITHUB_OUTPUT
+    "CodeCoverageEnabled=$($testResults.Configuration.CodeCoverage.Enabled.Value)" >> $env:GITHUB_OUTPUT
+    "CodeCoverageOutputPath=$($codeCoverageOutputFolderPath)" >> $env:GITHUB_OUTPUT
+    "Executed=$($testResults.Executed)" >> $env:GITHUB_OUTPUT
+    "Result=$($testResults.Result)" >> $env:GITHUB_OUTPUT
+    "FailedCount=$($testResults.FailedCount)" >> $env:GITHUB_OUTPUT
+    "FailedBlocksCount=$($testResults.FailedBlocksCount)" >> $env:GITHUB_OUTPUT
+    "FailedContainersCount=$($testResults.FailedContainersCount)" >> $env:GITHUB_OUTPUT
+    "PassedCount=$($testResults.PassedCount)" >> $env:GITHUB_OUTPUT
+    "SkippedCount=$($testResults.SkippedCount)" >> $env:GITHUB_OUTPUT
+    "InconclusiveCount=$($testResults.InconclusiveCount)" >> $env:GITHUB_OUTPUT
+    "NotRunCount=$($testResults.NotRunCount)" >> $env:GITHUB_OUTPUT
+    "TotalCount=$($testResults.TotalCount)" >> $env:GITHUB_OUTPUT
 
     if ($env:PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson -eq 'true' -and $testResults.Configuration.TestResult.Enabled.Value) {
         $jsonOutputPath = $testResults.Configuration.TestResult.OutputPath.Value -Replace '\.xml$', '.json'
@@ -144,21 +144,20 @@ LogGroup 'Eval - Set outputs' {
         Write-Output "Exporting code coverage results to [$jsonOutputPath]"
         $testResults.CodeCoverage | ConvertTo-Json -Depth 100 -Compress | Out-File -FilePath $jsonOutputPath
     }
-}
+    '::endgroup::'
 
-LogGroup 'Exit' {
+    '::group::Exit'
     if ($testResults.Result -eq 'Passed') {
-        Write-GitHubNotice '✅ All tests passed.'
+        '::notice::✅ All tests passed.'
         $script:exit = 0
     } else {
         if ($failedTests -gt 0) {
-            Write-GitHubError "❌ Some [$failedTests] tests failed."
+            "::error::❌ Some [$failedTests] tests failed."
             $script:exit = $failedTests
         } else {
-            Write-GitHubError '❌ Some tests failed.'
+            '::error::❌ Some tests failed.'
             $script:exit = 1
         }
     }
-}
 
-exit $script:exit
+    exit $script:exit


### PR DESCRIPTION
## Description

This pull request removed dependency on the `GitHub` PowerShell module, in order du use the framework to build the `GitHub` module. This include changes to the `scripts/exec.ps1` file to replace `LogGroup` blocks with GitHub Actions grouping commands and to update the way outputs and summaries are set.

### Changes to GitHub Actions grouping and output handling:

* Replaced `LogGroup` blocks with GitHub Actions grouping commands (`::group::` and `::endgroup::`). [[1]](diffhunk://#diff-9565c9ed6189efecf687222ac63d0ec9702c9708f75a02f7d9d9de9f86ae37a0L57-R79) [[2]](diffhunk://#diff-9565c9ed6189efecf687222ac63d0ec9702c9708f75a02f7d9d9de9f86ae37a0L100-R110) [[3]](diffhunk://#diff-9565c9ed6189efecf687222ac63d0ec9702c9708f75a02f7d9d9de9f86ae37a0L147-L162)
* Updated the method of setting GitHub step summaries to append content to `$env:GITHUB_STEP_SUMMARY` instead of using `Set-GitHubStepSummary`.
* Modified the way outputs are set by appending key-value pairs to `$env:GITHUB_OUTPUT` instead of using `Set-GitHubOutput`.
* Replaced `Write-GitHubNotice` and `Write-GitHubError` with their respective GitHub Actions commands (`::notice::` and `::error::`).

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
