### PR TITLE
🪲 [Fix]: Fix Path structure in Get-PesterTestTree filter

### DIFF
--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -667,7 +667,7 @@ filter Get-PesterTestTree {
 
         # Path to this node.
         [Parameter()]
-        [string[]] $Path
+        [string[]] $Path = @()
     )
 
     $children = [System.Collections.Generic.List[object]]::new()
@@ -675,14 +675,14 @@ filter Get-PesterTestTree {
     switch ($InputObject.GetType().Name) {
         'Run' {
             $Name = $InputObject.Configuration.TestResult.TestSuiteName.Value
-            $childPath = @($Path, $Name)
+            $childPath = , $Name
             $children.Add(($InputObject.Containers | Get-PesterTestTree -Path $childPath))
             $configuration = $InputObject.Configuration | ConvertFrom-PesterConfiguration
             [pscustomobject]@{
                 Depth                 = 0
                 ItemType              = 'TestSuite'
                 Name                  = $Name
-                Path                  = @()
+                Path                  = $null
                 Children              = $children
                 Result                = $InputObject.Result
                 FailedCount           = $InputObject.FailedCount
@@ -709,7 +709,7 @@ filter Get-PesterTestTree {
         }
         'Container' {
             $Name = (Split-Path $InputObject.Name -Leaf) -replace '.Tests.ps1'
-            $childPath = @($Path, $Name)
+            $childPath = $Path + $Name
             $children.Add(($InputObject.Blocks | Get-PesterTestTree -Path $childPath))
             [pscustomobject]@{
                 Depth                 = 1
@@ -741,7 +741,7 @@ filter Get-PesterTestTree {
         }
         'Block' {
             $Name = ($InputObject.ExpandedName)
-            $childPath = @($Path, $Name)
+            $childPath = $Path + $Name
             $children.Add(($InputObject.Order | Get-PesterTestTree -Path $childPath))
             [pscustomobject]@{
                 Depth                 = ($InputObject.Path.Count + 1)

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -994,7 +994,10 @@ filter Set-PesterReportTestsSummary {
             if ($InputObject.ErrorRecord) {
                 Details "$itemIndent$testStatusIcon - $testName ($formattedTestDuration)" {
                     CodeBlock 'pwsh' {
-                        $InputObject.ErrorRecord | Select-Object * | Format-List -Force | Out-String
+                        'Error:'
+                        $InputObject.ErrorRecord.DisplayErrorMessage
+                        'StackTrace:'
+                        $InputObject.ErrorRecord.DisplayStackTrace
                     } -Execute
                 }
             } else {

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -994,7 +994,7 @@ filter Set-PesterReportTestsSummary {
             if ($InputObject.ErrorRecord) {
                 Details "$itemIndent$testStatusIcon - $testName ($formattedTestDuration)" {
                     CodeBlock 'pwsh' {
-                        $InputObject.ErrorRecord -split [System.Environment]::NewLine
+                        $InputObject.ErrorRecord | Select-Object * | Format-List -Force | Out-String
                     } -Execute
                 }
             } else {

--- a/scripts/Helpers.psm1
+++ b/scripts/Helpers.psm1
@@ -994,9 +994,7 @@ filter Set-PesterReportTestsSummary {
             if ($InputObject.ErrorRecord) {
                 Details "$itemIndent$testStatusIcon - $testName ($formattedTestDuration)" {
                     CodeBlock 'pwsh' {
-                        'Error:'
                         $InputObject.ErrorRecord.DisplayErrorMessage
-                        'StackTrace:'
                         $InputObject.ErrorRecord.DisplayStackTrace
                     } -Execute
                 }


### PR DESCRIPTION
## Description

This pull request includes changes to the `Get-PesterTestTree` filter in the `scripts/Helpers.psm1` file to improve the handling of the `$Path` parameter and streamline the code.

Improvements to parameter handling and code simplification:

* Set default value of `$Path` parameter to an empty array to avoid potential null reference errors.
* Simplified the assignment of `$childPath` by directly concatenating `$Name` instead of creating a new array. [[1]](diffhunk://#diff-acb1351e3ba396afa6a397b0bd44b5d8ed3ffeb97a3f3ef3633e9cfd6cacf11aL670-R685) [[2]](diffhunk://#diff-acb1351e3ba396afa6a397b0bd44b5d8ed3ffeb97a3f3ef3633e9cfd6cacf11aL712-R712) [[3]](diffhunk://#diff-acb1351e3ba396afa6a397b0bd44b5d8ed3ffeb97a3f3ef3633e9cfd6cacf11aL744-R744)
* Changed the `Path` property assignment to `$null` instead of an empty array for consistency.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
