### PR TITLE
🚀 [Feature]: Add support for running a script before running the tests via `Prescript`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -122,6 +122,9 @@ jobs:
           WorkingDirectory: tests/1-Simple-Failure
           TestResult_TestSuiteName: 1-Simple-Failure
           StepSummary_ShowConfiguration: true
+          Prescript: |
+            Write-Host "This is a prescript"
+            Write-Host "We are running on ${{ runner.os }}"
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -122,9 +122,6 @@ jobs:
           WorkingDirectory: tests/1-Simple-Failure
           TestResult_TestSuiteName: 1-Simple-Failure
           StepSummary_ShowConfiguration: true
-          Prescript: |
-            Write-Host "This is a prescript"
-            Write-Host "We are running on ${{ runner.os }}"
 
       - name: Status
         shell: pwsh
@@ -179,6 +176,9 @@ jobs:
         with:
           WorkingDirectory: tests/2-Standard
           Output_CIFormat: GithubActions
+          Prescript: |
+            Write-Host "This is a prescript"
+            Write-Host "We are running on ${{ runner.os }}"
 
       - name: Status
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -259,60 +259,61 @@ jobs:
 *All inputs are optional unless noted otherwise. For more details, refer to the [Pester Configuration documentation](https://pester.dev/docs/usage/configuration).*
 `Run.PassThru` is forced to `$true` to ensure the action can capture test results.
 
-| **Input**                            | **Description**                                                                                        | **Default** |
-|--------------------------------------|--------------------------------------------------------------------------------------------------------|-------------|
-| `Path`                               | Path to where tests are located or a configuration file.                                               | *(none)*    |
-| `ReportAsJson`                       | Output generated reports in JSON format in addition to the configured format through Pester.           | `true`      |
+| **Input**                            | **Description**                                                                                                                                     | **Default** |
+|--------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| `Path`                               | Path to where tests are located or a configuration file.                                                                                            | *(none)*    |
+| `ReportAsJson`                       | Output generated reports in JSON format in addition to the configured format through Pester.                                                        | `true`      |
+| `Prescript`                          | Script to be executed before the test run. This script is executed in the same context as the test run.                                             | *(none)*    |
 | `StepSummary_Mode`                   | Controls which tests to show in the GitHub step summary. Allows "Full" (all tests), "Failed" (only failed tests), or "None" (disable step summary). | `Failed`    |
-| `StepSummary_ShowTestOverview`       | Controls whether to show the test overview table in the GitHub step summary.                           | `false`     |
-| `StepSummary_ShowConfiguration`      | Controls whether to show the configuration details in the GitHub step summary.                         | `false`     |
-| `Run_Path`                           | Directories/files to be searched for tests.                                                            | *(none)*    |
-| `Run_ExcludePath`                    | Directories/files to exclude from the run.                                                             | *(none)*    |
-| `Run_ScriptBlock`                    | ScriptBlocks containing tests to be executed.                                                          | *(none)*    |
-| `Run_Container`                      | ContainerInfo objects containing tests to be executed.                                                 | *(none)*    |
-| `Run_TestExtension`                  | Filter used to identify test files (e.g. `.Tests.ps1`).                                                | *(none)*    |
-| `Run_Exit`                           | Whether to exit with a non-zero exit code on failure.                                                  | *(none)*    |
-| `Run_Throw`                          | Whether to throw an exception on test failure.                                                         | *(none)*    |
-| `Run_SkipRun`                        | Discovery only, skip actual test run.                                                                  | *(none)*    |
-| `Run_SkipRemainingOnFailure`         | Skips remaining tests after the first failure. Options: `None`, `Run`, `Container`, `Block`.           | *(none)*    |
-| `Filter_Tag`                         | Tags of Describe/Context/It blocks to run.                                                             | *(none)*    |
-| `Filter_ExcludeTag`                  | Tags of Describe/Context/It blocks to exclude.                                                         | *(none)*    |
-| `Filter_Line`                        | Filter by file + scriptblock start line (e.g. `C:\tests\file1.Tests.ps1:37`).                          | *(none)*    |
-| `Filter_ExcludeLine`                 | Exclude by file + scriptblock start line. Precedence over `Filter_Line`.                               | *(none)*    |
-| `Filter_FullName`                    | Full name of a test with wildcards, joined by dot. E.g. `*.describe Get-Item.test1`                    | *(none)*    |
-| `CodeCoverage_Enabled`               | Enable code coverage.                                                                                  | *(none)*    |
-| `CodeCoverage_OutputFormat`          | Format for the coverage report. Possible values: `JaCoCo`, `CoverageGutters`, `Cobertura`.             | *(none)*    |
-| `CodeCoverage_OutputPath`            | Where to save the code coverage report (relative to the current dir).                                  | *(none)*    |
-| `CodeCoverage_OutputEncoding`        | Encoding of the coverage file.                                                                         | *(none)*    |
-| `CodeCoverage_Path`                  | Files/directories to measure coverage on (by default, reuses `Path` from the general settings).        | *(none)*    |
-| `CodeCoverage_ExcludeTests`          | Exclude tests themselves from coverage.                                                                | *(none)*    |
-| `CodeCoverage_RecursePaths`          | Recurse through coverage directories.                                                                  | *(none)*    |
-| `CodeCoverage_CoveragePercentTarget` | Desired minimum coverage percentage.                                                                   | *(none)*    |
-| `CodeCoverage_UseBreakpoints`        | **Experimental**: When `false`, use a Profiler-based tracer instead of breakpoints.                    | *(none)*    |
-| `CodeCoverage_SingleHitBreakpoints`  | Remove breakpoints after first hit.                                                                    | *(none)*    |
-| `TestResult_Enabled`                 | Enable test-result output (e.g. NUnitXml, JUnitXml).                                                   | *(none)*    |
-| `TestResult_OutputFormat`            | Possible values: `NUnitXml`, `NUnit2.5`, `NUnit3`, `JUnitXml`.                                         | *(none)*    |
-| `TestResult_OutputPath`              | Where to save the test-result report (relative path).                                                  | *(none)*    |
-| `TestResult_OutputEncoding`          | Encoding of the test-result file.                                                                      | *(none)*    |
-| `TestResult_TestSuiteName`           | Name used for the root `test-suite` element in the result file.                                        | *(none)*    |
-| `Should_ErrorAction`                 | Controls if `Should` throws on error. Use `Stop` to throw, or `Continue` to fail at the end.           | *(none)*    |
-| `Debug_ShowFullErrors`               | Show Pester internal stack on errors. (Deprecated – overrides `Output.StackTraceVerbosity` to `Full`). | *(none)*    |
-| `Debug_WriteDebugMessages`           | Write debug messages to screen.                                                                        | *(none)*    |
-| `Debug_WriteDebugMessagesFrom`       | Filter debug messages by source. Wildcards allowed.                                                    | *(none)*    |
-| `Debug_ShowNavigationMarkers`        | Write paths after every block/test for easy navigation in Visual Studio Code.                          | *(none)*    |
-| `Debug_ReturnRawResultObject`        | Returns an unfiltered result object, for development only.                                             | *(none)*    |
-| `Output_Verbosity`                   | Verbosity: `None`, `Normal`, `Detailed`, `Diagnostic`.                                                 | *(none)*    |
-| `Output_StackTraceVerbosity`         | Stacktrace detail: `None`, `FirstLine`, `Filtered`, `Full`.                                            | *(none)*    |
-| `Output_CIFormat`                    | CI format of error output: `None`, `Auto`, `AzureDevops`, `GithubActions`.                             | *(none)*    |
-| `Output_CILogLevel`                  | CI log level: `Error` or `Warning`.                                                                    | *(none)*    |
-| `Output_RenderMode`                  | How to render console output: `Auto`, `Ansi`, `ConsoleColor`, `Plaintext`.                             | *(none)*    |
-| `TestDrive_Enabled`                  | Enable `TestDrive`.                                                                                    | *(none)*    |
-| `TestRegistry_Enabled`               | Enable `TestRegistry`.                                                                                 | *(none)*    |
-| `Debug`                              | Enable debug output.                                                                                   | `false`     |
-| `Verbose`                            | Enable verbose output.                                                                                 | `false`     |
-| `Version`                            | Specifies the exact version of the GitHub module to install.                                           | *(none)*    |
-| `Prerelease`                         | Allow prerelease versions if available.                                                                | `false`     |
-| `WorkingDirectory`                   | The working directory where the script runs.                                                           | `.`         |
+| `StepSummary_ShowTestOverview`       | Controls whether to show the test overview table in the GitHub step summary.                                                                        | `false`     |
+| `StepSummary_ShowConfiguration`      | Controls whether to show the configuration details in the GitHub step summary.                                                                      | `false`     |
+| `Run_Path`                           | Directories/files to be searched for tests.                                                                                                         | *(none)*    |
+| `Run_ExcludePath`                    | Directories/files to exclude from the run.                                                                                                          | *(none)*    |
+| `Run_ScriptBlock`                    | ScriptBlocks containing tests to be executed.                                                                                                       | *(none)*    |
+| `Run_Container`                      | ContainerInfo objects containing tests to be executed.                                                                                              | *(none)*    |
+| `Run_TestExtension`                  | Filter used to identify test files (e.g. `.Tests.ps1`).                                                                                             | *(none)*    |
+| `Run_Exit`                           | Whether to exit with a non-zero exit code on failure.                                                                                               | *(none)*    |
+| `Run_Throw`                          | Whether to throw an exception on test failure.                                                                                                      | *(none)*    |
+| `Run_SkipRun`                        | Discovery only, skip actual test run.                                                                                                               | *(none)*    |
+| `Run_SkipRemainingOnFailure`         | Skips remaining tests after the first failure. Options: `None`, `Run`, `Container`, `Block`.                                                        | *(none)*    |
+| `Filter_Tag`                         | Tags of Describe/Context/It blocks to run.                                                                                                          | *(none)*    |
+| `Filter_ExcludeTag`                  | Tags of Describe/Context/It blocks to exclude.                                                                                                      | *(none)*    |
+| `Filter_Line`                        | Filter by file + scriptblock start line (e.g. `C:\tests\file1.Tests.ps1:37`).                                                                       | *(none)*    |
+| `Filter_ExcludeLine`                 | Exclude by file + scriptblock start line. Precedence over `Filter_Line`.                                                                            | *(none)*    |
+| `Filter_FullName`                    | Full name of a test with wildcards, joined by dot. E.g. `*.describe Get-Item.test1`                                                                 | *(none)*    |
+| `CodeCoverage_Enabled`               | Enable code coverage.                                                                                                                               | *(none)*    |
+| `CodeCoverage_OutputFormat`          | Format for the coverage report. Possible values: `JaCoCo`, `CoverageGutters`, `Cobertura`.                                                          | *(none)*    |
+| `CodeCoverage_OutputPath`            | Where to save the code coverage report (relative to the current dir).                                                                               | *(none)*    |
+| `CodeCoverage_OutputEncoding`        | Encoding of the coverage file.                                                                                                                      | *(none)*    |
+| `CodeCoverage_Path`                  | Files/directories to measure coverage on (by default, reuses `Path` from the general settings).                                                     | *(none)*    |
+| `CodeCoverage_ExcludeTests`          | Exclude tests themselves from coverage.                                                                                                             | *(none)*    |
+| `CodeCoverage_RecursePaths`          | Recurse through coverage directories.                                                                                                               | *(none)*    |
+| `CodeCoverage_CoveragePercentTarget` | Desired minimum coverage percentage.                                                                                                                | *(none)*    |
+| `CodeCoverage_UseBreakpoints`        | **Experimental**: When `false`, use a Profiler-based tracer instead of breakpoints.                                                                 | *(none)*    |
+| `CodeCoverage_SingleHitBreakpoints`  | Remove breakpoints after first hit.                                                                                                                 | *(none)*    |
+| `TestResult_Enabled`                 | Enable test-result output (e.g. NUnitXml, JUnitXml).                                                                                                | *(none)*    |
+| `TestResult_OutputFormat`            | Possible values: `NUnitXml`, `NUnit2.5`, `NUnit3`, `JUnitXml`.                                                                                      | *(none)*    |
+| `TestResult_OutputPath`              | Where to save the test-result report (relative path).                                                                                               | *(none)*    |
+| `TestResult_OutputEncoding`          | Encoding of the test-result file.                                                                                                                   | *(none)*    |
+| `TestResult_TestSuiteName`           | Name used for the root `test-suite` element in the result file.                                                                                     | *(none)*    |
+| `Should_ErrorAction`                 | Controls if `Should` throws on error. Use `Stop` to throw, or `Continue` to fail at the end.                                                        | *(none)*    |
+| `Debug_ShowFullErrors`               | Show Pester internal stack on errors. (Deprecated – overrides `Output.StackTraceVerbosity` to `Full`).                                              | *(none)*    |
+| `Debug_WriteDebugMessages`           | Write debug messages to screen.                                                                                                                     | *(none)*    |
+| `Debug_WriteDebugMessagesFrom`       | Filter debug messages by source. Wildcards allowed.                                                                                                 | *(none)*    |
+| `Debug_ShowNavigationMarkers`        | Write paths after every block/test for easy navigation in Visual Studio Code.                                                                       | *(none)*    |
+| `Debug_ReturnRawResultObject`        | Returns an unfiltered result object, for development only.                                                                                          | *(none)*    |
+| `Output_Verbosity`                   | Verbosity: `None`, `Normal`, `Detailed`, `Diagnostic`.                                                                                              | *(none)*    |
+| `Output_StackTraceVerbosity`         | Stacktrace detail: `None`, `FirstLine`, `Filtered`, `Full`.                                                                                         | *(none)*    |
+| `Output_CIFormat`                    | CI format of error output: `None`, `Auto`, `AzureDevops`, `GithubActions`.                                                                          | *(none)*    |
+| `Output_CILogLevel`                  | CI log level: `Error` or `Warning`.                                                                                                                 | *(none)*    |
+| `Output_RenderMode`                  | How to render console output: `Auto`, `Ansi`, `ConsoleColor`, `Plaintext`.                                                                          | *(none)*    |
+| `TestDrive_Enabled`                  | Enable `TestDrive`.                                                                                                                                 | *(none)*    |
+| `TestRegistry_Enabled`               | Enable `TestRegistry`.                                                                                                                              | *(none)*    |
+| `Debug`                              | Enable debug output.                                                                                                                                | `false`     |
+| `Verbose`                            | Enable verbose output.                                                                                                                              | `false`     |
+| `Version`                            | Specifies the exact version of the GitHub module to install.                                                                                        | *(none)*    |
+| `Prerelease`                         | Allow prerelease versions if available.                                                                                                             | `false`     |
+| `WorkingDirectory`                   | The working directory where the script runs.                                                                                                        | `.`         |
 
 ### Outputs
 
@@ -401,6 +402,28 @@ jobs:
           CodeCoverage_Path: './src'
           CodeCoverage_OutputPath: './coverage.xml'
           CodeCoverage_OutputFormat: 'JaCoCo'
+```
+
+### Import a module before pester runs
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Pester tests with prescript
+        id: pester
+        uses: PSModule/Invoke-Pester@v1
+        with:
+          Path: './tests'
+          CodeCoverage_Enabled: 'true'
+          CodeCoverage_Path: './src'
+          CodeCoverage_OutputPath: './coverage.xml'
+          CodeCoverage_OutputFormat: 'JaCoCo'
+          Prescript: |
+            Import-Module MyModule
 ```
 
 ## See Also

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
       Output generated reports in JSON format in addition to the configured format through Pester.
     required: false
     default: 'true'
+  Prescript:
+    description: |
+      Script to be executed before the test run. This script is executed in the same context as the test run.
+    required: false
   StepSummary_Mode:
     description: |
       Controls which tests to show in the GitHub step summary. Allows "Full" (show all tests), "Failed" (only failed tests), or "None" (disable step summary).
@@ -345,6 +349,7 @@ runs:
       id: test
       run: |
         # Invoke-Pester (exec)
+        ${{ inputs.Prescript }}
         ${{ github.action_path }}/scripts/exec.ps1
 
     - name: Upload test results - [${{ steps.test.outputs.TestSuiteName }}-TestResults]


### PR DESCRIPTION
## Description

This pull request introduces a new feature that allows users to run a prescript before executing tests. The changes include updates to the workflow configuration, documentation, and action inputs.

### New Feature: Prescript Execution

* [`.github/workflows/Action-Test.yml`](diffhunk://#diff-a12ae5c885b0673c0ff6f70c2670886907590d624626e07da4c52e01aeaf56a4R179-R181): Added a `Prescript` section to run custom scripts before the test execution.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L263-R266): Updated documentation to include the new `Prescript` input and provided an example of how to use it. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L263-R266) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R407-R428)
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R18-R21): Added the `Prescript` input to the action configuration, allowing users to specify a script to be executed before the test run. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R18-R21) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R352)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
