### PR TITLE
🪲 [Fix]: Add Debug and Verbose input options for Pester execution

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -346,6 +346,8 @@ runs:
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode: ${{ inputs.StepSummary_Mode }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview: ${{ inputs.StepSummary_ShowTestOverview }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration: ${{ inputs.StepSummary_ShowConfiguration }}
+        PSMODULE_INVOKE_PESTER_INPUT_Debug: ${{ inputs.Debug }}
+        PSMODULE_INVOKE_PESTER_INPUT_Verbose: ${{ inputs.Verbose }}
       id: test
       run: |
         # Invoke-Pester (exec)

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -1,6 +1,9 @@
 ﻿[CmdletBinding()]
 param()
 
+$DebugPreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
+$VerbosePreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
+
 $PSStyle.OutputRendering = 'Ansi'
 
 '::group::Exec - Setup prerequisites'


### PR DESCRIPTION
## Description

This pull request includes changes to add debug and verbose options to the PowerShell script execution process.

Enhancements to script execution:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R349-R350): Added new inputs `Debug` and `Verbose` to allow users to specify debug and verbose preferences.
* [`scripts/exec.ps1`](diffhunk://#diff-9565c9ed6189efecf687222ac63d0ec9702c9708f75a02f7d9d9de9f86ae37a0R4-R6): Configured `$DebugPreference` and `$VerbosePreference` based on the new environment variables `PSMODULE_INVOKE_PESTER_INPUT_Debug` and `PSMODULE_INVOKE_PESTER_INPUT_Verbose`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
