### PR TITLE
🪲 [Fix]: Fix an issue with exporting report while `$PSStyle.OutputRendering = Ansi`

### DIFF
--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -55,7 +55,9 @@ Get-Module | Format-Table -AutoSize | Out-String
 '::endgroup::'
 
 $configuration = New-PesterConfiguration -Hashtable $configuration
+$PSStyle.OutputRendering = 'Host'
 $testResults = Invoke-Pester -Configuration $configuration
+$PSStyle.OutputRendering = 'Ansi'
 
 '::group::Eval - Setup prerequisites'
 'Pester', 'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry

--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -55,7 +55,7 @@ Get-Module | Format-Table -AutoSize | Out-String
 '::endgroup::'
 
 $configuration = New-PesterConfiguration -Hashtable $configuration
-$PSStyle.OutputRendering = 'Host'
+$PSStyle.OutputRendering = 'Host' # Ensure propper XML rendering
 $testResults = Invoke-Pester -Configuration $configuration
 $PSStyle.OutputRendering = 'Ansi'
 


### PR DESCRIPTION
## Description

This pull request includes a small change to the `scripts/exec.ps1` file. The change ensures proper XML rendering during the execution of Pester tests by setting the `$PSStyle.OutputRendering` property to 'Host' before invoking Pester and resetting it to 'Ansi' afterward. 

* [`scripts/exec.ps1`](diffhunk://#diff-9565c9ed6189efecf687222ac63d0ec9702c9708f75a02f7d9d9de9f86ae37a0R58-R60): Added lines to set `$PSStyle.OutputRendering` to 'Host' before invoking Pester and reset it to 'Ansi' afterward to ensure proper XML rendering.

<details><summary>Error details:</summary>
<p>

```pwsh
Error: System.Management.Automation.RuntimeException: Invoking step End failed:
Message
  Result 1 - Error 1:Export-XmlReport: Exception calling "WriteElementString" with "2" argument(s): "'
  value 0x1B, is an invalid character."
  
  at Write-NUnitTestCaseAttributes, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17271
  at Write-NUnitTestCaseElement, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17165
  at Write-NUnitTestSuiteElements, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17037
  at Write-NUnitTestSuiteElements, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17009
  at Write-NUnitTestSuiteElements, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17009
  at Write-NUnitTestSuiteElements, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 17009
  at Write-NUnitTestResultChildNodes, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 16957
  at Write-NUnitReport, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 16911
  at Export-XmlReport, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 18156
  at Export-PesterResult, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 18012
  at <ScriptBlock>, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 18501
  at Invoke-PluginStep, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 1800
  at Invoke-Pester<End>, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 4991
  at <ScriptBlock>, /Users/runner/work/_actions/PSModule/Invoke-Pester/v4/scripts/exec.ps1: line 58
  at <ScriptBlock>, /Users/runner/work/_temp/c4fb2d93-33d3-4235-84c5-d06cd584c57a.ps1: line 5
  at <ScriptBlock>, <No file>: line 1
  
  at Assert-Success, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 1857
  at Invoke-PluginStep, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 1819
  at Invoke-Pester<End>, /Users/runner/.local/share/powershell/Modules/Pester/5.7.1/Pester.psm1: line 4991
  at <ScriptBlock>, /Users/runner/work/_actions/PSModule/Invoke-Pester/v4/scripts/exec.ps1: line 58
  at <ScriptBlock>, /Users/runner/work/_temp/c4fb2d93-33d3-4235-84c5-d06cd584c57a.ps1: line 5
  at <ScriptBlock>, <No file>: line 1
```

</p>
</details> 


## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
