### PR TITLE
🪲 [Fix]: Ensure that Debug and Verbose preferences are controllable

### DIFF
--- a/scripts/exec.ps1
+++ b/scripts/exec.ps1
@@ -3,10 +3,7 @@ param()
 
 $DebugPreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
 $VerbosePreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
-
 $PSStyle.OutputRendering = 'Ansi'
-$DebugPreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Debug ? 'Continue' : 'SilentlyContinue'
-$VerbosePreference = $env:PSMODULE_INVOKE_PESTER_INPUT_Verbose ? 'Continue' : 'SilentlyContinue'
 
 '::group::Exec - Setup prerequisites'
 Import-Module "$PSScriptRoot/Helpers.psm1"


### PR DESCRIPTION
## Description

This pull request includes a minor cleanup in the `scripts/exec.ps1` file to remove duplicate lines and streamline the script's setup process.

Code cleanup:

* Removed redundant assignments for `$DebugPreference` and `$VerbosePreference`, as these were already defined earlier in the script.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
