### PR TITLE
🚀[Feature]: Add `Notice_Mode` input to control test completion notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ jobs:
 | `Path`                               | Path to where tests are located or a configuration file.                                                                                            | *(none)*    |
 | `ReportAsJson`                       | Output generated reports in JSON format in addition to the configured format through Pester.                                                        | `true`      |
 | `Prescript`                          | Script to be executed before the test run. This script is executed in the same context as the test run.                                             | *(none)*    |
+| `Notice_Mode`                        | Controls when to show notices for test completion. Allows "Full" (show on success and failure), "Failed" (show only on failure), or "None" (disable notices). | `Failed`    |
 | `StepSummary_Mode`                   | Controls which tests to show in the GitHub step summary. Allows "Full" (all tests), "Failed" (only failed tests), or "None" (disable step summary). | `Failed`    |
 | `StepSummary_ShowTestOverview`       | Controls whether to show the test overview table in the GitHub step summary.                                                                        | `false`     |
 | `StepSummary_ShowConfiguration`      | Controls whether to show the configuration details in the GitHub step summary.                                                                      | `false`     |

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,11 @@ inputs:
     description: |
       Script to be executed before the test run. This script is executed in the same context as the test run.
     required: false
+  Notice_Mode:
+    description: |
+      Controls when to show notices for test completion. Allows "Full" (show on success and failure), "Failed" (show only on failure), or "None" (disable notices).
+    required: false
+    default: 'Failed'
   StepSummary_Mode:
     description: |
       Controls which tests to show in the GitHub step summary. Allows "Full" (show all tests), "Failed" (only failed tests), or "None" (disable step summary).
@@ -344,6 +349,7 @@ runs:
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
         PSMODULE_INVOKE_PESTER_INPUT_ReportAsJson: ${{ inputs.ReportAsJson }}
+        PSMODULE_INVOKE_PESTER_INPUT_Notice_Mode: ${{ inputs.Notice_Mode }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_Mode: ${{ inputs.StepSummary_Mode }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowTestOverview: ${{ inputs.StepSummary_ShowTestOverview }}
         PSMODULE_INVOKE_PESTER_INPUT_StepSummary_ShowConfiguration: ${{ inputs.StepSummary_ShowConfiguration }}


### PR DESCRIPTION
This release introduces a new `Notice_Mode` input parameter to control when GitHub notices are displayed for test completion. By default, notices are now only shown on test failure, providing more flexibility in managing action output verbosity.

- Fixes https://github.com/PSModule/Process-PSModule/issues/164

## What's New
- **New Input: `Notice_Mode`** - Controls when GitHub notices are displayed for test completion:
  - `Full`: Show notices on both success and failure.
  - `Failed` (default): Show notices only on failure.
  - `None`: Disable notices entirely.
  This provides more flexibility in managing action output verbosity.

## Changes
- Enhanced `scripts/exec.ps1` to conditionally display notices based on the new input.
- Updated `action.yml` to define the new input and pass it via environment variables.
- Updated `README.md` with input documentation.
- Minor fix: Corrected case in string replacement method calls.