### PR TITLE
⚙️ [Maintenance]: Update super-linter to v8.4.0

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.github/linters

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,7 +28,6 @@ jobs:
         uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -25,9 +25,10 @@ jobs:
           persist-credentials: false
 
       - name: Lint code base
-        uses: super-linter/super-linter@d5b0a2ab116623730dd094f15ddc1b6b25bf7b99 # v8.3.2
+        uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ to streamline continuous integration for PowerShell projects:
 The action's behavior is controlled by a **layered configuration** system, which merges settings from multiple sources in a specific order. The
 highest-priority settings override lower-priority ones. The order of precedence is as follows:
 
-| Setting    | Default | Test Suite | Direct Inputs | Result |
-|------------|---------|------------|---------------|--------|
-| `SettingA` | `X`     |            |               | `X`    |
-| `SettingB` | `X`     | `Y`        |               | `Y`    |
-| `SettingC` | `X`     | `Y`        | `Z`           | `Z`    |
+| Setting     | Default | Test Suite | Direct Inputs | Result |
+|-------------|---------|------------|---------------|--------|
+| `Setting_A` | `X`     |            |               | `X`    |
+| `Setting_B` | `X`     | `Y`        |               | `Y`    |
+| `Setting_C` | `X`     | `Y`        | `Z`           | `Z`    |
 
 This **last-write-wins** strategy means you can set global defaults while retaining the flexibility to override them at the action level.
 

--- a/src/exec.ps1
+++ b/src/exec.ps1
@@ -54,7 +54,7 @@ Get-Module | Format-Table -AutoSize | Out-String
 '::endgroup::'
 
 $configuration = New-PesterConfiguration -Hashtable $configuration
-$PSStyle.OutputRendering = 'Host' # Ensure propper XML rendering
+$PSStyle.OutputRendering = 'Host' # Ensure proper XML rendering
 $testResults = Invoke-Pester -Configuration $configuration
 $PSStyle.OutputRendering = 'Ansi'
 


### PR DESCRIPTION
## Description

Updates super-linter from v8.3.2 to v8.4.0.

## Changes

- Updated `super-linter/super-linter` to v8.4.0 (`12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e`)
- Added `.codespellrc` configuration file for codespell linter

## References

- [super-linter v8.4.0 release](https://github.com/super-linter/super-linter/releases/tag/v8.4.0)