### PR TITLE
⚙️ [Maintenance]: Lock Pester to the 6.x major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ If you specify `CodeCoverage_Enabled: true` here, it will enable coverage even i
 
 1. **Prerequisite Setup**
    - Installs required PowerShell modules if they're not present.
+   - Pester is locked to the `6.x` major version (`[6.0.0,7.0.0)`), so a future major release cannot be adopted silently.
    - Imports the modules so the testing framework is ready to use.
 2. **Loading Inputs and Configuration**
    - Loads a default Pester configuration.

--- a/src/Helpers.psm1
+++ b/src/Helpers.psm1
@@ -1319,7 +1319,7 @@ function Install-PSResourceWithRetry {
             TrustRepository = $true
             WarningAction   = 'SilentlyContinue'
         }
-        if (-not [string]::IsNullOrEmpty($Version)) {
+        if (-not [string]::IsNullOrWhiteSpace($Version)) {
             $installParams['Version'] = $Version
         }
         Write-Output "Installing module: $Name $Version".Trim()

--- a/src/Helpers.psm1
+++ b/src/Helpers.psm1
@@ -1298,6 +1298,11 @@ function Install-PSResourceWithRetry {
         )]
         [string] $Name,
 
+        # Version of the module to install. Accepts an exact version or a NuGet version range,
+        # e.g. '[6.0.0,7.0.0)' to lock to the 6.x major version. Defaults to the latest version.
+        [Parameter()]
+        [string] $Version,
+
         # Number of times to retry installation, default is 5
         [Parameter()]
         [int] $RetryCount = 5,
@@ -1308,10 +1313,19 @@ function Install-PSResourceWithRetry {
     )
 
     process {
-        Write-Output "Installing module: $Name"
+        $installParams = @{
+            Name            = $Name
+            Repository      = 'PSGallery'
+            TrustRepository = $true
+            WarningAction   = 'SilentlyContinue'
+        }
+        if (-not [string]::IsNullOrEmpty($Version)) {
+            $installParams['Version'] = $Version
+        }
+        Write-Output "Installing module: $Name $Version".Trim()
         for ($i = 0; $i -lt $RetryCount; $i++) {
             try {
-                Install-PSResource -Name $Name -WarningAction SilentlyContinue -TrustRepository -Repository PSGallery
+                Install-PSResource @installParams
                 break
             } catch {
                 Write-Warning "Installation of $Name failed with error: $_"

--- a/src/exec.ps1
+++ b/src/exec.ps1
@@ -7,7 +7,8 @@ $PSStyle.OutputRendering = 'Ansi'
 
 '::group::Exec - Setup prerequisites'
 Import-Module "$PSScriptRoot/Helpers.psm1"
-'Pester' | Install-PSResourceWithRetry
+# Lock Pester to the 6.x major version so a future major release cannot be adopted silently.
+Install-PSResourceWithRetry -Name 'Pester' -Version '[6.0.0,7.0.0)'
 '::endgroup::'
 
 '::group::Exec - Get test kit versions'
@@ -59,7 +60,9 @@ $testResults = Invoke-Pester -Configuration $configuration
 $PSStyle.OutputRendering = 'Ansi'
 
 '::group::Eval - Setup prerequisites'
-'Pester', 'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
+# Lock Pester to the 6.x major version so a future major release cannot be adopted silently.
+Install-PSResourceWithRetry -Name 'Pester' -Version '[6.0.0,7.0.0)'
+'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
 '::endgroup::'
 
 '::group::Eval - Get test kit versions'

--- a/src/init.ps1
+++ b/src/init.ps1
@@ -3,7 +3,9 @@ param()
 
 LogGroup 'Init - Setup prerequisites' {
     Import-Module "$PSScriptRoot/Helpers.psm1"
-    'Pester', 'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
+    # Lock Pester to the 6.x major version so a future major release cannot be adopted silently.
+    Install-PSResourceWithRetry -Name 'Pester' -Version '[6.0.0,7.0.0)'
+    'Hashtable', 'TimeSpan', 'Markdown' | Install-PSResourceWithRetry
 }
 
 LogGroup 'Init - Get test kit versions' {


### PR DESCRIPTION
The action now installs the latest Pester **6.x** rather than whatever the newest published Pester is, so a future major release can't be adopted automatically and break every consumer's test run at once.

## Changed: Pester is installed locked to the 6.x major

The action resolves Pester with the version range `[6.0.0,7.0.0)`, always installing the newest `6.x`. Consumers call the action exactly as before; only the resolved Pester major is constrained. Pester 6 keeps the classic `Should` assertion syntax, so this is low-risk for consumers.

## Technical Details

- `src/init.ps1` installs Pester via `Install-PSResourceWithRetry -Name 'Pester' -Version '[6.0.0,7.0.0)'`; the other modules still install the latest version.
- `src/Helpers.psm1`: `Install-PSResourceWithRetry` gains an optional `-Version` parameter passed through to `Install-PSResource` — groundwork toward the configurable version input tracked in #68.
- After release, bump the Invoke-Pester pin in `Process-PSModule`'s `Test-ModuleLocal.yml` so the lock reaches consumers. Part of the dependency-management epic PSModule/Process-PSModule#356.
